### PR TITLE
Restore indexable pages and legacy alias coverage

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>About us moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>About us moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/industrial-minerals-exporter-india/" />
-    <meta http-equiv="refresh" content="0; url=/industrial-minerals-exporter-india/" />
-    <script>window.location.replace("/industrial-minerals-exporter-india/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/industrial-minerals-exporter-india/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/industrial-minerals-exporter-india/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>About us moved to <a href="/industrial-minerals-exporter-india/">https://jadewavesenterprise.com/industrial-minerals-exporter-india/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>About us moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/industrial-minerals-exporter-india/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/activated-bleaching-earth/index.html
+++ b/activated-bleaching-earth/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Activated bleaching earth moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Activated bleaching earth moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
-    <meta http-equiv="refresh" content="0; url=/products/" />
-    <script>window.location.replace("/products/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Activated bleaching earth moved to <a href="/products/">https://jadewavesenterprise.com/products/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Activated bleaching earth moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/animal-feed-bentonite/index.html
+++ b/animal-feed-bentonite/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Animal feed bentonite page moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Animal feed bentonite moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
-    <meta http-equiv="refresh" content="0; url=/products/bentonite/" />
-    <script>window.location.replace("/products/bentonite/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Animal feed bentonite page moved to <a href="/products/bentonite/">https://jadewavesenterprise.com/products/bentonite/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Animal feed bentonite moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/bentonite/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/bentonite-supplier-india/index.html
+++ b/bentonite-supplier-india/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Bentonite page moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
-    <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
-    <meta http-equiv="refresh" content="0; url=/products/bentonite/" />
-    <script>window.location.replace("/products/bentonite/");</script>
+    <title>Bentonite supplier article moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
+    <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-supplier-india/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Bentonite page moved to <a href="/products/bentonite/">https://jadewavesenterprise.com/products/bentonite/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Bentonite supplier article moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/blog/bentonite-supplier-india/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/bentonite/index.html
+++ b/bentonite/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Bentonite moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Bentonite moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
-    <meta http-equiv="refresh" content="0; url=/products/bentonite/" />
-    <script>window.location.replace("/products/bentonite/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Bentonite moved to <a href="/products/bentonite/">https://jadewavesenterprise.com/products/bentonite/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Bentonite moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/bentonite/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/blog/bentonite-grade-selection-guide-for-importers/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/index.html
@@ -1,22 +1,195 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Blog Redirect | Jade Waves Enterprise</title>
-    <meta name="description" content="This article has been consolidated into the current Jade Waves content hub." />
-    <meta name="robots" content="noindex,follow" />
-    <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
-    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
-    <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>
-    <link rel="stylesheet" href="/styles.css" />
-  </head>
-  <body class="antialiased page-redirect">
-    <main class="shell" style="padding: 6rem 1.5rem;">
-      <p class="section-label">Redirecting</p>
-      <h1>Blog Redirect | Jade Waves Enterprise</h1>
-      <p>This article has been consolidated into the current Jade Waves content hub.</p>
-      <p><a href="/blog/">Continue to the current page</a></p>
-    </main>
-  </body>
-</html>
+            <html lang="en">
+              <head>
+                <meta charset="UTF-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                <title>Bentonite Grade Selection Guide for Import Buyers | Jade Waves</title>
+                <meta name="description" content="Import guide for selecting bentonite grades for drilling, foundry, piling, HDD, and earthing applications." />
+                <meta name="robots" content="index,follow" />
+                <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
+                <meta property="og:title" content="Bentonite Grade Selection Guide for Import Buyers | Jade Waves" />
+                <meta property="og:description" content="Import guide for selecting bentonite grades for drilling, foundry, piling, HDD, and earthing applications." />
+                <meta property="og:type" content="website" />
+                <meta property="og:url" content="https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
+                <meta property="og:site_name" content="Jade Waves Enterprise" />
+                <meta property="og:image" content="https://jadewavesenterprise.com/assets/jade-waves-logo-transparent.png" />
+                <link rel="preconnect" href="https://fonts.googleapis.com" />
+                <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+                <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+                <link rel="stylesheet" href="/styles.css" />
+                <script async src="https://www.googletagmanager.com/gtag/js?id=G-9BRL4JKNN6"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-9BRL4JKNN6');
+</script>
+                <script type="application/ld+json">[{"@context": "https://schema.org", "@type": "BlogPosting", "headline": "Bentonite Grade Selection Guide for Drilling, Foundry, and Civil Buyers", "description": "Import guide for selecting bentonite grades for drilling, foundry, piling, HDD, and earthing applications.", "mainEntityOfPage": "https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/", "url": "https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/", "datePublished": "2026-04-30", "dateModified": "2026-04-30", "author": {"@type": "Organization", "name": "Jade Waves Enterprise"}, "publisher": {"@type": "Organization", "name": "Jade Waves Enterprise", "logo": {"@type": "ImageObject", "url": "https://jadewavesenterprise.com/assets/jade-waves-logo-transparent.png"}}}, {"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "Home", "item": "https://jadewavesenterprise.com"}, {"@type": "ListItem", "position": 2, "name": "Blog", "item": "https://jadewavesenterprise.com/blog/"}, {"@type": "ListItem", "position": 3, "name": "Bentonite Grade Selection Guide for Drilling, Foundry, and Civil Buyers", "item": "https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/"}]}]</script>
+                <script defer src="/script.js"></script>
+              </head>
+              <body class="antialiased page-blog-post">
+                <header class="site-header" data-header>
+  <div class="site-header__inner">
+    <a class="brand-mark" href="/" aria-label="Jade Waves Enterprise home">
+      <img src="/assets/jade-waves-logo-transparent.png" alt="Jade Waves Enterprise logo" />
+    </a>
+    <nav class="desktop-nav" aria-label="Primary">
+      <a href="/#about">About</a>
+      <a href="/products/">Products</a>
+      <a href="/operations/">Operations</a>
+      <a href="/blog/">Blog</a>
+      <a href="/export-markets/">Markets</a>
+      <a href="/#contact">Contact</a>
+    </nav>
+    <div class="header-actions">
+      <a class="button button--dark button--compact" href="/#contact" data-set-request="Quote">Request Quote</a>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu" data-menu-toggle>
+        Menu
+      </button>
+    </div>
+  </div>
+  <div class="mobile-menu" id="mobile-menu" data-mobile-menu hidden>
+    <a href="/#about">About</a>
+    <a href="/products/">Products</a>
+    <a href="/operations/">Operations</a>
+    <a href="/blog/">Blog</a>
+    <a href="/export-markets/">Markets</a>
+    <a href="/#contact">Contact</a>
+  </div>
+</header>
+        <main>
+          <section class="hero hero--home">
+            <div class="hero__strata" aria-hidden="true">
+              <span class="strata strata--a"></span>
+              <span class="strata strata--b"></span>
+              <span class="strata strata--c"></span>
+              <span class="route-line route-line--hero"></span>
+            </div>
+            <div class="shell home-hero">
+              <div class="hero-copy hero-copy--home" data-reveal>
+                <p class="hero-label">Bentonite / Grade Selection</p>
+                <h1>Bentonite Grade Selection Guide for Drilling, Foundry, and Civil Buyers</h1>
+                <p class="hero-text">How buyers shortlist bentonite grades by application and avoid mismatched trials.</p>
+                <div class="hero-actions">
+                  <a class="button button--light" href="/products/bentonite/">Open Bentonite</a>
+                  <a class="button button--ghost" href="/#contact" data-set-request="Quote">Request Quote</a>
+                </div>
+              </div>
+            </div>
+            <div class="shell proof-strip" data-reveal>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">From this guide</span>
+                <strong>What to confirm before RFQ</strong>
+              </article>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">Primary product</span>
+                <strong>Bentonite</strong>
+              </article>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">Move to technicals</span>
+                <strong><a href="/products/bentonite/">Open product page</a></strong>
+              </article>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">Move to inquiry</span>
+                <strong><a href="/#contact" data-set-request="Quote">Send requirement</a></strong>
+              </article>
+            </div>
+          </section>
+
+          <section class="section-block">
+            <div class="shell section-shell">
+              <div class="blog-layout">
+                <article class="blog-article">
+                  <section class="blog-article-section" data-reveal>
+  <h2>Map grade to application performance</h2>
+  <p>Bentonite buying should be led by function: swelling behavior, viscosity response, and moisture stability.</p>
+  <ul class="bullet-list">
+    <li>Define exact application: drilling, foundry, piling, HDD, earthing, or sealing.</li><li>Share process condition where rheology matters.</li><li>Confirm handling and storage realities at destination.</li>
+  </ul>
+</section><section class="blog-article-section" data-reveal>
+  <h2>Clarify form and usage plan</h2>
+  <p>Lumps and powder behave differently in handling and blending systems.</p>
+  <ul class="bullet-list">
+    <li>Choose supply form based on your dosing method.</li><li>Share expected monthly volume and trial target.</li><li>Ask for grade consistency approach for repeat shipments.</li>
+  </ul>
+</section><section class="blog-article-section" data-reveal>
+  <h2>Commercial fit should follow technical fit</h2>
+  <p>Quoting first and qualifying later often increases cost and delay.</p>
+  <ul class="bullet-list">
+    <li>Confirm grade shortlist before rate comparison.</li><li>Align packing and shipment terms to your site setup.</li><li>Keep documentation and dispatch updates in one owner flow.</li>
+  </ul>
+</section>
+                </article>
+                <aside class="blog-sidecard" data-reveal>
+                  <p class="section-label">Buyer RFQ checklist</p>
+                  <h2>Share these details in your first inquiry.</h2>
+                  <ul class="bullet-list">
+                    <li>Which bentonite grade fits our exact application?</li><li>What technical references can you share for that grade?</li><li>How do you handle repeat-batch consistency?</li><li>What are the practical timelines for shipment?</li>
+                  </ul>
+                  <div class="related-links blog-sidecard__links">
+                    <a href="/products/bentonite/">Open Bentonite</a>
+                    <a href="/operations/">See operations</a>
+                    <a href="/#contact" data-set-request="Quote">Send inquiry</a>
+                  </div>
+                </aside>
+              </div>
+            </div>
+          </section>
+
+          <section class="section-block section-block--contrast">
+            <div class="shell section-shell">
+              <div class="section-topline section-topline--stack" data-reveal>
+                <div class="section-topline__copy">
+                  <p class="section-kicker">Related guides</p>
+                  <h2>Continue with nearby buyer questions.</h2>
+                </div>
+                <a class="section-link" href="/blog/">Open all guides</a>
+              </div>
+              <div class="blog-grid blog-grid--compact">
+                <a class="blog-card blog-card--compact" href="/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" data-reveal>
+  <p class="blog-card__eyebrow">Quartz Sand / Vietnam / Ceramics-Glass</p>
+  <h3>Quartz Sand Supplier from India: Buyer Checklist for Vietnam Ceramics and Glass Teams</h3>
+  <p>What import buyers should confirm before RFQ when sourcing quartz sand, grits, and powder from India.</p>
+</a><a class="blog-card blog-card--compact" href="/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" data-reveal>
+  <p class="blog-card__eyebrow">Feldspar / Ceramics-Glass / Import Guide</p>
+  <h3>Potassium vs Sodium Feldspar: What Import Buyers Should Confirm Before Buying</h3>
+  <p>How buyers compare potash and soda feldspar grades for ceramic and glass applications before quote.</p>
+</a><a class="blog-card blog-card--compact" href="/blog/silica-sand-import-checklist-glass-foundry-filtration/" data-reveal>
+  <p class="blog-card__eyebrow">Silica Sand / Buyer Checklist</p>
+  <h3>Silica Sand Import Checklist for Glass, Foundry, and Filtration Buyers</h3>
+  <p>A practical import checklist for buyers comparing silica sand suppliers and preparing a clean RFQ.</p>
+</a>
+              </div>
+            </div>
+          </section>
+        </main>
+        <footer class="site-footer">
+  <div class="shell site-footer__inner">
+    <div>
+      <p class="footer-label">Jade Waves Enterprise</p>
+      <p class="footer-copy">Industrial minerals, supplied with more control.</p>
+    </div>
+    <div class="footer-grid">
+      <div>
+        <p class="footer-heading">Contact</p>
+        <a href="tel:+91-999-883-5503">+91-999-883-5503</a>
+        <a href="mailto:deep@jadewavesenterprise.com">deep@jadewavesenterprise.com</a>
+      </div>
+      <div>
+        <p class="footer-heading">Navigate</p>
+        <a href="/">Home</a>
+        <a href="/products/">Products</a>
+        <a href="/operations/">Operations</a>
+        <a href="/blog/">Blog</a>
+        <a href="/hear-from-ceo/">Hear from Our CEO</a>
+        <a href="/export-markets/">Export Markets</a>
+        <a href="/#contact">Contact</a>
+      </div>
+    </div>
+  </div>
+  <div class="shell site-footer__meta">
+    <p>&copy; <span data-current-year>2026</span> Jade Waves Enterprise. All rights reserved.</p>
+  </div>
+</footer>
+              </body>
+            </html>

--- a/blog/bentonite-supplier-india/index.html
+++ b/blog/bentonite-supplier-india/index.html
@@ -1,22 +1,201 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Blog Redirect | Jade Waves Enterprise</title>
-    <meta name="description" content="This article has been consolidated into the current Jade Waves content hub." />
-    <meta name="robots" content="noindex,follow" />
-    <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
-    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
-    <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>
-    <link rel="stylesheet" href="/styles.css" />
-  </head>
-  <body class="antialiased page-redirect">
-    <main class="shell" style="padding: 6rem 1.5rem;">
-      <p class="section-label">Redirecting</p>
-      <h1>Blog Redirect | Jade Waves Enterprise</h1>
-      <p>This article has been consolidated into the current Jade Waves content hub.</p>
-      <p><a href="/blog/">Continue to the current page</a></p>
-    </main>
-  </body>
-</html>
+            <html lang="en">
+              <head>
+                <meta charset="UTF-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                <title>Bentonite Supplier India | Grades, Quality Focus, and Export Supply</title>
+                <meta name="description" content="Bentonite supply from India with sodium and calcium grades, quality focus points, and export support for industrial buyers." />
+                <meta name="robots" content="index,follow" />
+                <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
+                <meta property="og:title" content="Bentonite Supplier India | Grades, Quality Focus, and Export Supply" />
+                <meta property="og:description" content="Bentonite supply from India with sodium and calcium grades, quality focus points, and export support for industrial buyers." />
+                <meta property="og:type" content="website" />
+                <meta property="og:url" content="https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
+                <meta property="og:site_name" content="Jade Waves Enterprise" />
+                <meta property="og:image" content="https://jadewavesenterprise.com/assets/jade-waves-logo-transparent.png" />
+                <link rel="preconnect" href="https://fonts.googleapis.com" />
+                <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+                <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+                <link rel="stylesheet" href="/styles.css" />
+                <script async src="https://www.googletagmanager.com/gtag/js?id=G-9BRL4JKNN6"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-9BRL4JKNN6');
+</script>
+                <script type="application/ld+json">[{"@context": "https://schema.org", "@type": "BlogPosting", "headline": "Bentonite Supplier India: What We Offer", "description": "Bentonite supply from India with sodium and calcium grades, quality focus points, and export support for industrial buyers.", "mainEntityOfPage": "https://jadewavesenterprise.com/blog/bentonite-supplier-india/", "url": "https://jadewavesenterprise.com/blog/bentonite-supplier-india/", "datePublished": "2026-04-30", "dateModified": "2026-04-30", "author": {"@type": "Organization", "name": "Jade Waves Enterprise"}, "publisher": {"@type": "Organization", "name": "Jade Waves Enterprise", "logo": {"@type": "ImageObject", "url": "https://jadewavesenterprise.com/assets/jade-waves-logo-transparent.png"}}}, {"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "Home", "item": "https://jadewavesenterprise.com"}, {"@type": "ListItem", "position": 2, "name": "Blog", "item": "https://jadewavesenterprise.com/blog/"}, {"@type": "ListItem", "position": 3, "name": "Bentonite Supplier India: What We Offer", "item": "https://jadewavesenterprise.com/blog/bentonite-supplier-india/"}]}]</script>
+                <script defer src="/script.js"></script>
+              </head>
+              <body class="antialiased page-blog-post">
+                <header class="site-header" data-header>
+  <div class="site-header__inner">
+    <a class="brand-mark" href="/" aria-label="Jade Waves Enterprise home">
+      <img src="/assets/jade-waves-logo-transparent.png" alt="Jade Waves Enterprise logo" />
+    </a>
+    <nav class="desktop-nav" aria-label="Primary">
+      <a href="/#about">About</a>
+      <a href="/products/">Products</a>
+      <a href="/operations/">Operations</a>
+      <a href="/blog/">Blog</a>
+      <a href="/export-markets/">Markets</a>
+      <a href="/#contact">Contact</a>
+    </nav>
+    <div class="header-actions">
+      <a class="button button--dark button--compact" href="/#contact" data-set-request="Quote">Request Quote</a>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu" data-menu-toggle>
+        Menu
+      </button>
+    </div>
+  </div>
+  <div class="mobile-menu" id="mobile-menu" data-mobile-menu hidden>
+    <a href="/#about">About</a>
+    <a href="/products/">Products</a>
+    <a href="/operations/">Operations</a>
+    <a href="/blog/">Blog</a>
+    <a href="/export-markets/">Markets</a>
+    <a href="/#contact">Contact</a>
+  </div>
+</header>
+        <main>
+          <section class="hero hero--home">
+            <div class="hero__strata" aria-hidden="true">
+              <span class="strata strata--a"></span>
+              <span class="strata strata--b"></span>
+              <span class="strata strata--c"></span>
+              <span class="route-line route-line--hero"></span>
+            </div>
+            <div class="shell home-hero">
+              <div class="hero-copy hero-copy--home" data-reveal>
+                <p class="hero-label">Bentonite / India Supply</p>
+                <h1>Bentonite Supplier India: What We Offer</h1>
+                <p class="hero-text">A direct bentonite supply guide for buyers comparing grades, application fit, and export handling from India.</p>
+                <div class="hero-actions">
+                  <a class="button button--light" href="/products/bentonite/">Open Bentonite</a>
+                  <a class="button button--ghost" href="/#contact" data-set-request="Quote">Request Quote</a>
+                </div>
+              </div>
+            </div>
+            <div class="shell proof-strip" data-reveal>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">From this guide</span>
+                <strong>What to confirm before RFQ</strong>
+              </article>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">Primary product</span>
+                <strong>Bentonite</strong>
+              </article>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">Move to technicals</span>
+                <strong><a href="/products/bentonite/">Open product page</a></strong>
+              </article>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">Move to inquiry</span>
+                <strong><a href="/#contact" data-set-request="Quote">Send requirement</a></strong>
+              </article>
+            </div>
+          </section>
+
+          <section class="section-block">
+            <div class="shell section-shell">
+              <div class="blog-layout">
+                <article class="blog-article">
+                  <section class="blog-article-section" data-reveal>
+  <h2>What we offer</h2>
+  <p>If your requirement is bentonite from India, the first step is to align the right grade against the actual application rather than treat every bentonite discussion as interchangeable.</p>
+  <ul class="bullet-list">
+    <li>Supply includes sodium bentonite, calcium bentonite, and application-specific grades</li><li>Activated bleaching earth sits within the broader bentonite portfolio</li><li>Commercial discussion is aligned to application, grade type, and packing basis together</li>
+  </ul>
+</section><section class="blog-article-section" data-reveal>
+  <h2>Where the bentonite line is used</h2>
+  <p>Bentonite performance depends heavily on the end use, so buyers usually need application fit clarified before pricing moves too far.</p>
+  <ul class="bullet-list">
+    <li>Drilling fluids for oil, gas, and HDD</li><li>Foundry and casting systems</li><li>Construction, sealing, and waterproofing work</li><li>Cat litter, absorbent use, and bleaching earth programs</li>
+  </ul>
+</section><section class="blog-article-section" data-reveal>
+  <h2>Quality focus before quotation</h2>
+  <p>Technical alignment matters most when buyers need trial approval and repeat shipment performance to stay on the same basis.</p>
+  <ul class="bullet-list">
+    <li>Application requirement and sodium or calcium grade are aligned first</li><li>pH, liquid limit, viscosity, moisture, and filtrate loss are reviewed against end use</li><li>Packing and order volume are handled with the quality discussion</li>
+  </ul>
+</section><section class="blog-article-section" data-reveal>
+  <h2>Supply and export setup</h2>
+  <p>Export execution becomes cleaner when sample, document, and shipment basis are kept in one buyer-facing conversation from the start.</p>
+  <ul class="bullet-list">
+    <li>Packing: 50 Kg bags and jumbo bags</li><li>Shipment mode: FCL</li><li>Export handling includes sample alignment, document alignment, and shipment planning from India</li>
+  </ul>
+</section>
+                </article>
+                <aside class="blog-sidecard" data-reveal>
+                  <p class="section-label">Buyer RFQ checklist</p>
+                  <h2>Share these details in your first inquiry.</h2>
+                  <ul class="bullet-list">
+                    <li>Application and process context</li><li>Required grade type: sodium, calcium, or application-specific</li><li>Key acceptance parameters such as viscosity, pH, liquid limit, and filtrate loss</li><li>Trial quantity and expected monthly volume</li><li>Destination port and preferred packing basis</li>
+                  </ul>
+                  <div class="related-links blog-sidecard__links">
+                    <a href="/products/bentonite/">Open Bentonite</a>
+                    <a href="/operations/">See operations</a>
+                    <a href="/#contact" data-set-request="Quote">Send inquiry</a>
+                  </div>
+                </aside>
+              </div>
+            </div>
+          </section>
+
+          <section class="section-block section-block--contrast">
+            <div class="shell section-shell">
+              <div class="section-topline section-topline--stack" data-reveal>
+                <div class="section-topline__copy">
+                  <p class="section-kicker">Related guides</p>
+                  <h2>Continue with nearby buyer questions.</h2>
+                </div>
+                <a class="section-link" href="/blog/">Open all guides</a>
+              </div>
+              <div class="blog-grid blog-grid--compact">
+                <a class="blog-card blog-card--compact" href="/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" data-reveal>
+  <p class="blog-card__eyebrow">Quartz Sand / Vietnam / Ceramics-Glass</p>
+  <h3>Quartz Sand Supplier from India: Buyer Checklist for Vietnam Ceramics and Glass Teams</h3>
+  <p>What import buyers should confirm before RFQ when sourcing quartz sand, grits, and powder from India.</p>
+</a><a class="blog-card blog-card--compact" href="/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" data-reveal>
+  <p class="blog-card__eyebrow">Feldspar / Ceramics-Glass / Import Guide</p>
+  <h3>Potassium vs Sodium Feldspar: What Import Buyers Should Confirm Before Buying</h3>
+  <p>How buyers compare potash and soda feldspar grades for ceramic and glass applications before quote.</p>
+</a><a class="blog-card blog-card--compact" href="/blog/silica-sand-import-checklist-glass-foundry-filtration/" data-reveal>
+  <p class="blog-card__eyebrow">Silica Sand / Buyer Checklist</p>
+  <h3>Silica Sand Import Checklist for Glass, Foundry, and Filtration Buyers</h3>
+  <p>A practical import checklist for buyers comparing silica sand suppliers and preparing a clean RFQ.</p>
+</a>
+              </div>
+            </div>
+          </section>
+        </main>
+        <footer class="site-footer">
+  <div class="shell site-footer__inner">
+    <div>
+      <p class="footer-label">Jade Waves Enterprise</p>
+      <p class="footer-copy">Industrial minerals, supplied with more control.</p>
+    </div>
+    <div class="footer-grid">
+      <div>
+        <p class="footer-heading">Contact</p>
+        <a href="tel:+91-999-883-5503">+91-999-883-5503</a>
+        <a href="mailto:deep@jadewavesenterprise.com">deep@jadewavesenterprise.com</a>
+      </div>
+      <div>
+        <p class="footer-heading">Navigate</p>
+        <a href="/">Home</a>
+        <a href="/products/">Products</a>
+        <a href="/operations/">Operations</a>
+        <a href="/blog/">Blog</a>
+        <a href="/hear-from-ceo/">Hear from Our CEO</a>
+        <a href="/export-markets/">Export Markets</a>
+        <a href="/#contact">Contact</a>
+      </div>
+    </div>
+  </div>
+  <div class="shell site-footer__meta">
+    <p>&copy; <span data-current-year>2026</span> Jade Waves Enterprise. All rights reserved.</p>
+  </div>
+</footer>
+              </body>
+            </html>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/index.html
@@ -1,22 +1,201 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Blog Redirect | Jade Waves Enterprise</title>
-    <meta name="description" content="This article has been consolidated into the current Jade Waves content hub." />
-    <meta name="robots" content="noindex,follow" />
-    <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
-    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
-    <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>
-    <link rel="stylesheet" href="/styles.css" />
-  </head>
-  <body class="antialiased page-redirect">
-    <main class="shell" style="padding: 6rem 1.5rem;">
-      <p class="section-label">Redirecting</p>
-      <h1>Blog Redirect | Jade Waves Enterprise</h1>
-      <p>This article has been consolidated into the current Jade Waves content hub.</p>
-      <p><a href="/blog/">Continue to the current page</a></p>
-    </main>
-  </body>
-</html>
+            <html lang="en">
+              <head>
+                <meta charset="UTF-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                <title>Copper Slag Supplier for Shipyard Blasting | Sizes and Export Supply</title>
+                <meta name="description" content="Copper slag grit supply for shipyard blasting with available sizes, key performance focus points, and export handling support." />
+                <meta name="robots" content="index,follow" />
+                <link rel="canonical" href="https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
+                <meta property="og:title" content="Copper Slag Supplier for Shipyard Blasting | Sizes and Export Supply" />
+                <meta property="og:description" content="Copper slag grit supply for shipyard blasting with available sizes, key performance focus points, and export handling support." />
+                <meta property="og:type" content="website" />
+                <meta property="og:url" content="https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
+                <meta property="og:site_name" content="Jade Waves Enterprise" />
+                <meta property="og:image" content="https://jadewavesenterprise.com/assets/jade-waves-logo-transparent.png" />
+                <link rel="preconnect" href="https://fonts.googleapis.com" />
+                <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+                <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+                <link rel="stylesheet" href="/styles.css" />
+                <script async src="https://www.googletagmanager.com/gtag/js?id=G-9BRL4JKNN6"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-9BRL4JKNN6');
+</script>
+                <script type="application/ld+json">[{"@context": "https://schema.org", "@type": "BlogPosting", "headline": "Copper Slag Supplier for Shipyard Blasting: What We Supply", "description": "Copper slag grit supply for shipyard blasting with available sizes, key performance focus points, and export handling support.", "mainEntityOfPage": "https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/", "url": "https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/", "datePublished": "2026-04-30", "dateModified": "2026-04-30", "author": {"@type": "Organization", "name": "Jade Waves Enterprise"}, "publisher": {"@type": "Organization", "name": "Jade Waves Enterprise", "logo": {"@type": "ImageObject", "url": "https://jadewavesenterprise.com/assets/jade-waves-logo-transparent.png"}}}, {"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "Home", "item": "https://jadewavesenterprise.com"}, {"@type": "ListItem", "position": 2, "name": "Blog", "item": "https://jadewavesenterprise.com/blog/"}, {"@type": "ListItem", "position": 3, "name": "Copper Slag Supplier for Shipyard Blasting: What We Supply", "item": "https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/"}]}]</script>
+                <script defer src="/script.js"></script>
+              </head>
+              <body class="antialiased page-blog-post">
+                <header class="site-header" data-header>
+  <div class="site-header__inner">
+    <a class="brand-mark" href="/" aria-label="Jade Waves Enterprise home">
+      <img src="/assets/jade-waves-logo-transparent.png" alt="Jade Waves Enterprise logo" />
+    </a>
+    <nav class="desktop-nav" aria-label="Primary">
+      <a href="/#about">About</a>
+      <a href="/products/">Products</a>
+      <a href="/operations/">Operations</a>
+      <a href="/blog/">Blog</a>
+      <a href="/export-markets/">Markets</a>
+      <a href="/#contact">Contact</a>
+    </nav>
+    <div class="header-actions">
+      <a class="button button--dark button--compact" href="/#contact" data-set-request="Quote">Request Quote</a>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu" data-menu-toggle>
+        Menu
+      </button>
+    </div>
+  </div>
+  <div class="mobile-menu" id="mobile-menu" data-mobile-menu hidden>
+    <a href="/#about">About</a>
+    <a href="/products/">Products</a>
+    <a href="/operations/">Operations</a>
+    <a href="/blog/">Blog</a>
+    <a href="/export-markets/">Markets</a>
+    <a href="/#contact">Contact</a>
+  </div>
+</header>
+        <main>
+          <section class="hero hero--home">
+            <div class="hero__strata" aria-hidden="true">
+              <span class="strata strata--a"></span>
+              <span class="strata strata--b"></span>
+              <span class="strata strata--c"></span>
+              <span class="route-line route-line--hero"></span>
+            </div>
+            <div class="shell home-hero">
+              <div class="hero-copy hero-copy--home" data-reveal>
+                <p class="hero-label">Copper Slag / Shipyard Blasting</p>
+                <h1>Copper Slag Supplier for Shipyard Blasting: What We Supply</h1>
+                <p class="hero-text">A direct copper slag grit guide for shipyard blasting buyers reviewing sizes, performance focus, and export handling from India.</p>
+                <div class="hero-actions">
+                  <a class="button button--light" href="/products/copper-slag/">Open Copper Slag</a>
+                  <a class="button button--ghost" href="/#contact" data-set-request="Quote">Request Quote</a>
+                </div>
+              </div>
+            </div>
+            <div class="shell proof-strip" data-reveal>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">From this guide</span>
+                <strong>What to confirm before RFQ</strong>
+              </article>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">Primary product</span>
+                <strong>Copper Slag</strong>
+              </article>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">Move to technicals</span>
+                <strong><a href="/products/copper-slag/">Open product page</a></strong>
+              </article>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">Move to inquiry</span>
+                <strong><a href="/#contact" data-set-request="Quote">Send requirement</a></strong>
+              </article>
+            </div>
+          </section>
+
+          <section class="section-block">
+            <div class="shell section-shell">
+              <div class="blog-layout">
+                <article class="blog-article">
+                  <section class="blog-article-section" data-reveal>
+  <h2>What we offer</h2>
+  <p>If your requirement is copper slag for shipyard blasting, the first step is to align the required size range and blasting basis before quotation.</p>
+  <ul class="bullet-list">
+    <li>Current supply form is copper slag grit</li><li>Commercial discussion is aligned to blasting requirement and size range together</li><li>Packing and shipment planning are handled with the performance discussion</li>
+  </ul>
+</section><section class="blog-article-section" data-reveal>
+  <h2>Readily available sizes</h2>
+  <p>Blasting buyers usually need the size range locked early because it directly affects surface preparation outcome and material consumption.</p>
+  <ul class="bullet-list">
+    <li>4.00-3.00 mm</li><li>3.00-2.36 mm</li><li>2.36-1.00 mm</li><li>1.00-0.50 mm, 0.50-0.212 mm, and 0.212 mm and below</li>
+  </ul>
+</section><section class="blog-article-section" data-reveal>
+  <h2>Performance focus before quotation</h2>
+  <p>Technical alignment matters before PO so the blasting media basis stays clear through sample, quotation, and dispatch.</p>
+  <ul class="bullet-list">
+    <li>Sieve size distribution is aligned first</li><li>Density, hardness, and angular grain profile are reviewed against blasting need</li><li>Packing and shipment volume are handled together with the size discussion</li>
+  </ul>
+</section><section class="blog-article-section" data-reveal>
+  <h2>Supply and export setup</h2>
+  <p>Shipyard blasting programs usually move faster when the size basis, cargo handling, and dispatch timeline are aligned early.</p>
+  <ul class="bullet-list">
+    <li>Packing: jumbo bags</li><li>Shipment mode: FCL</li><li>Export handling includes sample alignment, document alignment, and shipment planning from India based on destination and order size</li>
+  </ul>
+</section>
+                </article>
+                <aside class="blog-sidecard" data-reveal>
+                  <p class="section-label">Buyer RFQ checklist</p>
+                  <h2>Share these details in your first inquiry.</h2>
+                  <ul class="bullet-list">
+                    <li>Required blasting size range</li><li>Surface preparation requirement or blasting standard</li><li>Trial quantity and expected monthly volume</li><li>Destination port and preferred packing basis</li><li>Required delivery timing</li>
+                  </ul>
+                  <div class="related-links blog-sidecard__links">
+                    <a href="/products/copper-slag/">Open Copper Slag</a>
+                    <a href="/operations/">See operations</a>
+                    <a href="/#contact" data-set-request="Quote">Send inquiry</a>
+                  </div>
+                </aside>
+              </div>
+            </div>
+          </section>
+
+          <section class="section-block section-block--contrast">
+            <div class="shell section-shell">
+              <div class="section-topline section-topline--stack" data-reveal>
+                <div class="section-topline__copy">
+                  <p class="section-kicker">Related guides</p>
+                  <h2>Continue with nearby buyer questions.</h2>
+                </div>
+                <a class="section-link" href="/blog/">Open all guides</a>
+              </div>
+              <div class="blog-grid blog-grid--compact">
+                <a class="blog-card blog-card--compact" href="/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" data-reveal>
+  <p class="blog-card__eyebrow">Quartz Sand / Vietnam / Ceramics-Glass</p>
+  <h3>Quartz Sand Supplier from India: Buyer Checklist for Vietnam Ceramics and Glass Teams</h3>
+  <p>What import buyers should confirm before RFQ when sourcing quartz sand, grits, and powder from India.</p>
+</a><a class="blog-card blog-card--compact" href="/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" data-reveal>
+  <p class="blog-card__eyebrow">Feldspar / Ceramics-Glass / Import Guide</p>
+  <h3>Potassium vs Sodium Feldspar: What Import Buyers Should Confirm Before Buying</h3>
+  <p>How buyers compare potash and soda feldspar grades for ceramic and glass applications before quote.</p>
+</a><a class="blog-card blog-card--compact" href="/blog/silica-sand-import-checklist-glass-foundry-filtration/" data-reveal>
+  <p class="blog-card__eyebrow">Silica Sand / Buyer Checklist</p>
+  <h3>Silica Sand Import Checklist for Glass, Foundry, and Filtration Buyers</h3>
+  <p>A practical import checklist for buyers comparing silica sand suppliers and preparing a clean RFQ.</p>
+</a>
+              </div>
+            </div>
+          </section>
+        </main>
+        <footer class="site-footer">
+  <div class="shell site-footer__inner">
+    <div>
+      <p class="footer-label">Jade Waves Enterprise</p>
+      <p class="footer-copy">Industrial minerals, supplied with more control.</p>
+    </div>
+    <div class="footer-grid">
+      <div>
+        <p class="footer-heading">Contact</p>
+        <a href="tel:+91-999-883-5503">+91-999-883-5503</a>
+        <a href="mailto:deep@jadewavesenterprise.com">deep@jadewavesenterprise.com</a>
+      </div>
+      <div>
+        <p class="footer-heading">Navigate</p>
+        <a href="/">Home</a>
+        <a href="/products/">Products</a>
+        <a href="/operations/">Operations</a>
+        <a href="/blog/">Blog</a>
+        <a href="/hear-from-ceo/">Hear from Our CEO</a>
+        <a href="/export-markets/">Export Markets</a>
+        <a href="/#contact">Contact</a>
+      </div>
+    </div>
+  </div>
+  <div class="shell site-footer__meta">
+    <p>&copy; <span data-current-year>2026</span> Jade Waves Enterprise. All rights reserved.</p>
+  </div>
+</footer>
+              </body>
+            </html>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
@@ -1,22 +1,201 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Blog Redirect | Jade Waves Enterprise</title>
-    <meta name="description" content="This article has been consolidated into the current Jade Waves content hub." />
-    <meta name="robots" content="noindex,follow" />
-    <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
-    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
-    <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>
-    <link rel="stylesheet" href="/styles.css" />
-  </head>
-  <body class="antialiased page-redirect">
-    <main class="shell" style="padding: 6rem 1.5rem;">
-      <p class="section-label">Redirecting</p>
-      <h1>Blog Redirect | Jade Waves Enterprise</h1>
-      <p>This article has been consolidated into the current Jade Waves content hub.</p>
-      <p><a href="/blog/">Continue to the current page</a></p>
-    </main>
-  </body>
-</html>
+            <html lang="en">
+              <head>
+                <meta charset="UTF-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                <title>Fly Ash Exporter from India Bulk Shipment | Forms, Quality Focus, Export Supply</title>
+                <meta name="description" content="Fly ash export supply from India with dry and bulk forms, quality focus points, and dispatch planning for import buyers." />
+                <meta name="robots" content="index,follow" />
+                <link rel="canonical" href="https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
+                <meta property="og:title" content="Fly Ash Exporter from India Bulk Shipment | Forms, Quality Focus, Export Supply" />
+                <meta property="og:description" content="Fly ash export supply from India with dry and bulk forms, quality focus points, and dispatch planning for import buyers." />
+                <meta property="og:type" content="website" />
+                <meta property="og:url" content="https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
+                <meta property="og:site_name" content="Jade Waves Enterprise" />
+                <meta property="og:image" content="https://jadewavesenterprise.com/assets/jade-waves-logo-transparent.png" />
+                <link rel="preconnect" href="https://fonts.googleapis.com" />
+                <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+                <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+                <link rel="stylesheet" href="/styles.css" />
+                <script async src="https://www.googletagmanager.com/gtag/js?id=G-9BRL4JKNN6"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-9BRL4JKNN6');
+</script>
+                <script type="application/ld+json">[{"@context": "https://schema.org", "@type": "BlogPosting", "headline": "Fly Ash Exporter from India Bulk Shipment: What We Supply", "description": "Fly ash export supply from India with dry and bulk forms, quality focus points, and dispatch planning for import buyers.", "mainEntityOfPage": "https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/", "url": "https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/", "datePublished": "2026-04-30", "dateModified": "2026-04-30", "author": {"@type": "Organization", "name": "Jade Waves Enterprise"}, "publisher": {"@type": "Organization", "name": "Jade Waves Enterprise", "logo": {"@type": "ImageObject", "url": "https://jadewavesenterprise.com/assets/jade-waves-logo-transparent.png"}}}, {"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "Home", "item": "https://jadewavesenterprise.com"}, {"@type": "ListItem", "position": 2, "name": "Blog", "item": "https://jadewavesenterprise.com/blog/"}, {"@type": "ListItem", "position": 3, "name": "Fly Ash Exporter from India Bulk Shipment: What We Supply", "item": "https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/"}]}]</script>
+                <script defer src="/script.js"></script>
+              </head>
+              <body class="antialiased page-blog-post">
+                <header class="site-header" data-header>
+  <div class="site-header__inner">
+    <a class="brand-mark" href="/" aria-label="Jade Waves Enterprise home">
+      <img src="/assets/jade-waves-logo-transparent.png" alt="Jade Waves Enterprise logo" />
+    </a>
+    <nav class="desktop-nav" aria-label="Primary">
+      <a href="/#about">About</a>
+      <a href="/products/">Products</a>
+      <a href="/operations/">Operations</a>
+      <a href="/blog/">Blog</a>
+      <a href="/export-markets/">Markets</a>
+      <a href="/#contact">Contact</a>
+    </nav>
+    <div class="header-actions">
+      <a class="button button--dark button--compact" href="/#contact" data-set-request="Quote">Request Quote</a>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu" data-menu-toggle>
+        Menu
+      </button>
+    </div>
+  </div>
+  <div class="mobile-menu" id="mobile-menu" data-mobile-menu hidden>
+    <a href="/#about">About</a>
+    <a href="/products/">Products</a>
+    <a href="/operations/">Operations</a>
+    <a href="/blog/">Blog</a>
+    <a href="/export-markets/">Markets</a>
+    <a href="/#contact">Contact</a>
+  </div>
+</header>
+        <main>
+          <section class="hero hero--home">
+            <div class="hero__strata" aria-hidden="true">
+              <span class="strata strata--a"></span>
+              <span class="strata strata--b"></span>
+              <span class="strata strata--c"></span>
+              <span class="route-line route-line--hero"></span>
+            </div>
+            <div class="shell home-hero">
+              <div class="hero-copy hero-copy--home" data-reveal>
+                <p class="hero-label">Fly Ash / Bulk Shipment</p>
+                <h1>Fly Ash Exporter from India Bulk Shipment: What We Supply</h1>
+                <p class="hero-text">A direct fly ash supply guide for buyers reviewing forms, application fit, and bulk shipment handling from India.</p>
+                <div class="hero-actions">
+                  <a class="button button--light" href="/products/fly-ash/">Open Fly Ash</a>
+                  <a class="button button--ghost" href="/#contact" data-set-request="Quote">Request Quote</a>
+                </div>
+              </div>
+            </div>
+            <div class="shell proof-strip" data-reveal>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">From this guide</span>
+                <strong>What to confirm before RFQ</strong>
+              </article>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">Primary product</span>
+                <strong>Fly Ash</strong>
+              </article>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">Move to technicals</span>
+                <strong><a href="/products/fly-ash/">Open product page</a></strong>
+              </article>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">Move to inquiry</span>
+                <strong><a href="/#contact" data-set-request="Quote">Send requirement</a></strong>
+              </article>
+            </div>
+          </section>
+
+          <section class="section-block">
+            <div class="shell section-shell">
+              <div class="blog-layout">
+                <article class="blog-article">
+                  <section class="blog-article-section" data-reveal>
+  <h2>What we offer</h2>
+  <p>If your team is sourcing fly ash from India, the first step is to align the supply form and unloading setup before quotation and dispatch planning start.</p>
+  <ul class="bullet-list">
+    <li>Current supply discussions include dry fly ash and bulk fly ash</li><li>Application fit is aligned before commercial discussion</li><li>Packing, unloading, and shipment planning are handled together with the material conversation</li>
+  </ul>
+</section><section class="blog-article-section" data-reveal>
+  <h2>Where the fly ash line is used</h2>
+  <p>Buyers usually need the replacement role and handling basis clarified early because fly ash decisions are tied closely to the receiving process.</p>
+  <ul class="bullet-list">
+    <li>Cement and concrete production</li><li>Fly ash bricks and blocks</li><li>Roads and embankments</li><li>Infrastructure-linked mineral substitution</li>
+  </ul>
+</section><section class="blog-article-section" data-reveal>
+  <h2>Quality focus before quotation</h2>
+  <p>Technical alignment should happen before pricing so the quoted supply basis matches the replacement target and receiving setup.</p>
+  <ul class="bullet-list">
+    <li>Application and replacement target are aligned first</li><li>SiO2 and Al2O3 profile are reviewed against the required basis</li><li>Packing format, dispatch volume, and schedule are handled with the quality discussion</li>
+  </ul>
+</section><section class="blog-article-section" data-reveal>
+  <h2>Supply and export setup</h2>
+  <p>For bulk-oriented fly ash buying, the shipment basis matters almost as much as the chemistry once dispatch planning begins.</p>
+  <ul class="bullet-list">
+    <li>Packing: jumbo bags</li><li>Shipment mode: FCL</li><li>Export handling includes sample alignment, document alignment, and shipment planning from India based on destination and order size</li>
+  </ul>
+</section>
+                </article>
+                <aside class="blog-sidecard" data-reveal>
+                  <p class="section-label">Buyer RFQ checklist</p>
+                  <h2>Share these details in your first inquiry.</h2>
+                  <ul class="bullet-list">
+                    <li>End use and replacement target</li><li>Required chemistry or acceptance basis</li><li>Preferred packing and unloading setup</li><li>Trial quantity and expected monthly volume</li><li>Destination port and delivery timing</li>
+                  </ul>
+                  <div class="related-links blog-sidecard__links">
+                    <a href="/products/fly-ash/">Open Fly Ash</a>
+                    <a href="/operations/">See operations</a>
+                    <a href="/#contact" data-set-request="Quote">Send inquiry</a>
+                  </div>
+                </aside>
+              </div>
+            </div>
+          </section>
+
+          <section class="section-block section-block--contrast">
+            <div class="shell section-shell">
+              <div class="section-topline section-topline--stack" data-reveal>
+                <div class="section-topline__copy">
+                  <p class="section-kicker">Related guides</p>
+                  <h2>Continue with nearby buyer questions.</h2>
+                </div>
+                <a class="section-link" href="/blog/">Open all guides</a>
+              </div>
+              <div class="blog-grid blog-grid--compact">
+                <a class="blog-card blog-card--compact" href="/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" data-reveal>
+  <p class="blog-card__eyebrow">Quartz Sand / Vietnam / Ceramics-Glass</p>
+  <h3>Quartz Sand Supplier from India: Buyer Checklist for Vietnam Ceramics and Glass Teams</h3>
+  <p>What import buyers should confirm before RFQ when sourcing quartz sand, grits, and powder from India.</p>
+</a><a class="blog-card blog-card--compact" href="/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" data-reveal>
+  <p class="blog-card__eyebrow">Feldspar / Ceramics-Glass / Import Guide</p>
+  <h3>Potassium vs Sodium Feldspar: What Import Buyers Should Confirm Before Buying</h3>
+  <p>How buyers compare potash and soda feldspar grades for ceramic and glass applications before quote.</p>
+</a><a class="blog-card blog-card--compact" href="/blog/silica-sand-import-checklist-glass-foundry-filtration/" data-reveal>
+  <p class="blog-card__eyebrow">Silica Sand / Buyer Checklist</p>
+  <h3>Silica Sand Import Checklist for Glass, Foundry, and Filtration Buyers</h3>
+  <p>A practical import checklist for buyers comparing silica sand suppliers and preparing a clean RFQ.</p>
+</a>
+              </div>
+            </div>
+          </section>
+        </main>
+        <footer class="site-footer">
+  <div class="shell site-footer__inner">
+    <div>
+      <p class="footer-label">Jade Waves Enterprise</p>
+      <p class="footer-copy">Industrial minerals, supplied with more control.</p>
+    </div>
+    <div class="footer-grid">
+      <div>
+        <p class="footer-heading">Contact</p>
+        <a href="tel:+91-999-883-5503">+91-999-883-5503</a>
+        <a href="mailto:deep@jadewavesenterprise.com">deep@jadewavesenterprise.com</a>
+      </div>
+      <div>
+        <p class="footer-heading">Navigate</p>
+        <a href="/">Home</a>
+        <a href="/products/">Products</a>
+        <a href="/operations/">Operations</a>
+        <a href="/blog/">Blog</a>
+        <a href="/hear-from-ceo/">Hear from Our CEO</a>
+        <a href="/export-markets/">Export Markets</a>
+        <a href="/#contact">Contact</a>
+      </div>
+    </div>
+  </div>
+  <div class="shell site-footer__meta">
+    <p>&copy; <span data-current-year>2026</span> Jade Waves Enterprise. All rights reserved.</p>
+  </div>
+</footer>
+              </body>
+            </html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -24,7 +24,7 @@
   gtag('js', new Date());
   gtag('config', 'G-9BRL4JKNN6');
 </script>
-                <script type="application/ld+json">[{"@context": "https://schema.org", "@type": "CollectionPage", "name": "Buyer and Importer Blog", "url": "https://jadewavesenterprise.com/blog/", "description": "Buyer guide hub for import teams reviewing industrial mineral sourcing, specification checks, and export planning from India."}, {"@context": "https://schema.org", "@type": "ItemList", "name": "Published Buyer Guides", "itemListElement": [{"@type": "ListItem", "position": 1, "url": "https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/", "name": "Quartz Sand Supplier from India: Buyer Checklist for Vietnam Ceramics and Glass Teams"}, {"@type": "ListItem", "position": 2, "url": "https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/", "name": "Potassium vs Sodium Feldspar: What Import Buyers Should Confirm Before Buying"}, {"@type": "ListItem", "position": 3, "url": "https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/", "name": "Silica Sand Import Checklist for Glass, Foundry, and Filtration Buyers"}, {"@type": "ListItem", "position": 4, "url": "https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/", "name": "Potassium Feldspar Supplier for Ceramic Tiles: Export-Ready Supply for Manufacturers"}, {"@type": "ListItem", "position": 5, "url": "https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/", "name": "Quartz Powder Supplier for Engineered Stone: What We Supply"}, {"@type": "ListItem", "position": 6, "url": "https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/", "name": "Silica Sand Exporter from India: What We Supply"}, {"@type": "ListItem", "position": 7, "url": "https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/", "name": "How to Check TDS and Sample COA Before You Place a Mineral Import Order"}]}]</script>
+                <script type="application/ld+json">[{"@context": "https://schema.org", "@type": "CollectionPage", "name": "Buyer and Importer Blog", "url": "https://jadewavesenterprise.com/blog/", "description": "Buyer guide hub for import teams reviewing industrial mineral sourcing, specification checks, and export planning from India."}, {"@context": "https://schema.org", "@type": "ItemList", "name": "Published Buyer Guides", "itemListElement": [{"@type": "ListItem", "position": 1, "url": "https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/", "name": "Quartz Sand Supplier from India: Buyer Checklist for Vietnam Ceramics and Glass Teams"}, {"@type": "ListItem", "position": 2, "url": "https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/", "name": "Potassium vs Sodium Feldspar: What Import Buyers Should Confirm Before Buying"}, {"@type": "ListItem", "position": 3, "url": "https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/", "name": "Silica Sand Import Checklist for Glass, Foundry, and Filtration Buyers"}, {"@type": "ListItem", "position": 4, "url": "https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/", "name": "Bentonite Grade Selection Guide for Drilling, Foundry, and Civil Buyers"}, {"@type": "ListItem", "position": 5, "url": "https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/", "name": "Industrial Salt Import Guide for UAE, Oman, Qatar, and Kuwait Buyers"}, {"@type": "ListItem", "position": 6, "url": "https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/", "name": "Potassium Feldspar Supplier for Ceramic Tiles: Export-Ready Supply for Manufacturers"}, {"@type": "ListItem", "position": 7, "url": "https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/", "name": "Kaolin Supplier for Paint Industry: What We Supply"}, {"@type": "ListItem", "position": 8, "url": "https://jadewavesenterprise.com/blog/bentonite-supplier-india/", "name": "Bentonite Supplier India: What We Offer"}, {"@type": "ListItem", "position": 9, "url": "https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/", "name": "Fly Ash Exporter from India Bulk Shipment: What We Supply"}, {"@type": "ListItem", "position": 10, "url": "https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/", "name": "Copper Slag Supplier for Shipyard Blasting: What We Supply"}, {"@type": "ListItem", "position": 11, "url": "https://jadewavesenterprise.com/blog/industrial-salt-exporter/", "name": "Industrial Salt Exporter: What We Supply"}, {"@type": "ListItem", "position": 12, "url": "https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/", "name": "Quartz Powder Supplier for Engineered Stone: What We Supply"}, {"@type": "ListItem", "position": 13, "url": "https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/", "name": "Silica Sand Exporter from India: What We Supply"}, {"@type": "ListItem", "position": 14, "url": "https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/", "name": "How to Check TDS and Sample COA Before You Place a Mineral Import Order"}]}]</script>
                 <script defer src="/script.js"></script>
               </head>
               <body class="antialiased page-blog">
@@ -133,12 +133,68 @@
     <a class="blog-card__link blog-card__link--alt" href="/products/silica-sand/">Silica Sand</a>
   </div>
 </article><article class="blog-card" data-reveal>
+  <p class="blog-card__eyebrow">Bentonite / Grade Selection</p>
+  <h3>Bentonite Grade Selection Guide for Drilling, Foundry, and Civil Buyers</h3>
+  <p>How buyers shortlist bentonite grades by application and avoid mismatched trials.</p>
+  <div class="blog-card__actions">
+    <a class="blog-card__link" href="/blog/bentonite-grade-selection-guide-for-importers/">Read guide</a>
+    <a class="blog-card__link blog-card__link--alt" href="/products/bentonite/">Bentonite</a>
+  </div>
+</article><article class="blog-card" data-reveal>
+  <p class="blog-card__eyebrow">Salt / Gulf Importers</p>
+  <h3>Industrial Salt Import Guide for UAE, Oman, Qatar, and Kuwait Buyers</h3>
+  <p>A buyer-side guide for industrial salt sourcing from India with packaging and dispatch clarity.</p>
+  <div class="blog-card__actions">
+    <a class="blog-card__link" href="/blog/industrial-salt-import-guide-gulf-buyers/">Read guide</a>
+    <a class="blog-card__link blog-card__link--alt" href="/products/salt/">Salt</a>
+  </div>
+</article><article class="blog-card" data-reveal>
   <p class="blog-card__eyebrow">Potassium Feldspar / Ceramic Tiles</p>
   <h3>Potassium Feldspar Supplier for Ceramic Tiles: Export-Ready Supply for Manufacturers</h3>
   <p>A direct buyer guide for ceramic tile manufacturers reviewing potassium feldspar grade fit, particle size alignment, and export handling from India.</p>
   <div class="blog-card__actions">
     <a class="blog-card__link" href="/blog/potassium-feldspar-supplier-for-ceramic-tiles/">Read guide</a>
     <a class="blog-card__link blog-card__link--alt" href="/products/feldspar/">Feldspar</a>
+  </div>
+</article><article class="blog-card" data-reveal>
+  <p class="blog-card__eyebrow">Kaolin / Paint Industry</p>
+  <h3>Kaolin Supplier for Paint Industry: What We Supply</h3>
+  <p>A direct kaolin supply guide for paint and coatings buyers reviewing forms, brightness focus, and export handling from India.</p>
+  <div class="blog-card__actions">
+    <a class="blog-card__link" href="/blog/kaolin-supplier-for-paint-industry/">Read guide</a>
+    <a class="blog-card__link blog-card__link--alt" href="/products/kaolin--china-clay/">Kaolin (China Clay)</a>
+  </div>
+</article><article class="blog-card" data-reveal>
+  <p class="blog-card__eyebrow">Bentonite / India Supply</p>
+  <h3>Bentonite Supplier India: What We Offer</h3>
+  <p>A direct bentonite supply guide for buyers comparing grades, application fit, and export handling from India.</p>
+  <div class="blog-card__actions">
+    <a class="blog-card__link" href="/blog/bentonite-supplier-india/">Read guide</a>
+    <a class="blog-card__link blog-card__link--alt" href="/products/bentonite/">Bentonite</a>
+  </div>
+</article><article class="blog-card" data-reveal>
+  <p class="blog-card__eyebrow">Fly Ash / Bulk Shipment</p>
+  <h3>Fly Ash Exporter from India Bulk Shipment: What We Supply</h3>
+  <p>A direct fly ash supply guide for buyers reviewing forms, application fit, and bulk shipment handling from India.</p>
+  <div class="blog-card__actions">
+    <a class="blog-card__link" href="/blog/fly-ash-exporter-from-india-bulk-shipment/">Read guide</a>
+    <a class="blog-card__link blog-card__link--alt" href="/products/fly-ash/">Fly Ash</a>
+  </div>
+</article><article class="blog-card" data-reveal>
+  <p class="blog-card__eyebrow">Copper Slag / Shipyard Blasting</p>
+  <h3>Copper Slag Supplier for Shipyard Blasting: What We Supply</h3>
+  <p>A direct copper slag grit guide for shipyard blasting buyers reviewing sizes, performance focus, and export handling from India.</p>
+  <div class="blog-card__actions">
+    <a class="blog-card__link" href="/blog/copper-slag-supplier-for-shipyard-blasting/">Read guide</a>
+    <a class="blog-card__link blog-card__link--alt" href="/products/copper-slag/">Copper Slag</a>
+  </div>
+</article><article class="blog-card" data-reveal>
+  <p class="blog-card__eyebrow">Industrial Salt / Export Supply</p>
+  <h3>Industrial Salt Exporter: What We Supply</h3>
+  <p>A direct supply guide for buyers comparing industrial salt grades, packing basis, and export handling from India.</p>
+  <div class="blog-card__actions">
+    <a class="blog-card__link" href="/blog/industrial-salt-exporter/">Read guide</a>
+    <a class="blog-card__link blog-card__link--alt" href="/products/salt/">Salt</a>
   </div>
 </article><article class="blog-card" data-reveal>
   <p class="blog-card__eyebrow">Quartz Powder / Engineered Stone</p>

--- a/blog/industrial-salt-exporter/index.html
+++ b/blog/industrial-salt-exporter/index.html
@@ -1,22 +1,201 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Blog Redirect | Jade Waves Enterprise</title>
-    <meta name="description" content="This article has been consolidated into the current Jade Waves content hub." />
-    <meta name="robots" content="noindex,follow" />
-    <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
-    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
-    <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>
-    <link rel="stylesheet" href="/styles.css" />
-  </head>
-  <body class="antialiased page-redirect">
-    <main class="shell" style="padding: 6rem 1.5rem;">
-      <p class="section-label">Redirecting</p>
-      <h1>Blog Redirect | Jade Waves Enterprise</h1>
-      <p>This article has been consolidated into the current Jade Waves content hub.</p>
-      <p><a href="/blog/">Continue to the current page</a></p>
-    </main>
-  </body>
-</html>
+            <html lang="en">
+              <head>
+                <meta charset="UTF-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                <title>Industrial Salt Exporter | Grades, Packing, and Export Supply from India</title>
+                <meta name="description" content="Industrial salt export supply from India with multiple grades, quality focus points, and shipment support for import buyers." />
+                <meta name="robots" content="index,follow" />
+                <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
+                <meta property="og:title" content="Industrial Salt Exporter | Grades, Packing, and Export Supply from India" />
+                <meta property="og:description" content="Industrial salt export supply from India with multiple grades, quality focus points, and shipment support for import buyers." />
+                <meta property="og:type" content="website" />
+                <meta property="og:url" content="https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
+                <meta property="og:site_name" content="Jade Waves Enterprise" />
+                <meta property="og:image" content="https://jadewavesenterprise.com/assets/jade-waves-logo-transparent.png" />
+                <link rel="preconnect" href="https://fonts.googleapis.com" />
+                <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+                <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+                <link rel="stylesheet" href="/styles.css" />
+                <script async src="https://www.googletagmanager.com/gtag/js?id=G-9BRL4JKNN6"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-9BRL4JKNN6');
+</script>
+                <script type="application/ld+json">[{"@context": "https://schema.org", "@type": "BlogPosting", "headline": "Industrial Salt Exporter: What We Supply", "description": "Industrial salt export supply from India with multiple grades, quality focus points, and shipment support for import buyers.", "mainEntityOfPage": "https://jadewavesenterprise.com/blog/industrial-salt-exporter/", "url": "https://jadewavesenterprise.com/blog/industrial-salt-exporter/", "datePublished": "2026-04-30", "dateModified": "2026-04-30", "author": {"@type": "Organization", "name": "Jade Waves Enterprise"}, "publisher": {"@type": "Organization", "name": "Jade Waves Enterprise", "logo": {"@type": "ImageObject", "url": "https://jadewavesenterprise.com/assets/jade-waves-logo-transparent.png"}}}, {"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "Home", "item": "https://jadewavesenterprise.com"}, {"@type": "ListItem", "position": 2, "name": "Blog", "item": "https://jadewavesenterprise.com/blog/"}, {"@type": "ListItem", "position": 3, "name": "Industrial Salt Exporter: What We Supply", "item": "https://jadewavesenterprise.com/blog/industrial-salt-exporter/"}]}]</script>
+                <script defer src="/script.js"></script>
+              </head>
+              <body class="antialiased page-blog-post">
+                <header class="site-header" data-header>
+  <div class="site-header__inner">
+    <a class="brand-mark" href="/" aria-label="Jade Waves Enterprise home">
+      <img src="/assets/jade-waves-logo-transparent.png" alt="Jade Waves Enterprise logo" />
+    </a>
+    <nav class="desktop-nav" aria-label="Primary">
+      <a href="/#about">About</a>
+      <a href="/products/">Products</a>
+      <a href="/operations/">Operations</a>
+      <a href="/blog/">Blog</a>
+      <a href="/export-markets/">Markets</a>
+      <a href="/#contact">Contact</a>
+    </nav>
+    <div class="header-actions">
+      <a class="button button--dark button--compact" href="/#contact" data-set-request="Quote">Request Quote</a>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu" data-menu-toggle>
+        Menu
+      </button>
+    </div>
+  </div>
+  <div class="mobile-menu" id="mobile-menu" data-mobile-menu hidden>
+    <a href="/#about">About</a>
+    <a href="/products/">Products</a>
+    <a href="/operations/">Operations</a>
+    <a href="/blog/">Blog</a>
+    <a href="/export-markets/">Markets</a>
+    <a href="/#contact">Contact</a>
+  </div>
+</header>
+        <main>
+          <section class="hero hero--home">
+            <div class="hero__strata" aria-hidden="true">
+              <span class="strata strata--a"></span>
+              <span class="strata strata--b"></span>
+              <span class="strata strata--c"></span>
+              <span class="route-line route-line--hero"></span>
+            </div>
+            <div class="shell home-hero">
+              <div class="hero-copy hero-copy--home" data-reveal>
+                <p class="hero-label">Industrial Salt / Export Supply</p>
+                <h1>Industrial Salt Exporter: What We Supply</h1>
+                <p class="hero-text">A direct supply guide for buyers comparing industrial salt grades, packing basis, and export handling from India.</p>
+                <div class="hero-actions">
+                  <a class="button button--light" href="/products/salt/">Open Salt</a>
+                  <a class="button button--ghost" href="/#contact" data-set-request="Quote">Request Quote</a>
+                </div>
+              </div>
+            </div>
+            <div class="shell proof-strip" data-reveal>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">From this guide</span>
+                <strong>What to confirm before RFQ</strong>
+              </article>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">Primary product</span>
+                <strong>Salt</strong>
+              </article>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">Move to technicals</span>
+                <strong><a href="/products/salt/">Open product page</a></strong>
+              </article>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">Move to inquiry</span>
+                <strong><a href="/#contact" data-set-request="Quote">Send requirement</a></strong>
+              </article>
+            </div>
+          </section>
+
+          <section class="section-block">
+            <div class="shell section-shell">
+              <div class="blog-layout">
+                <article class="blog-article">
+                  <section class="blog-article-section" data-reveal>
+  <h2>What we offer</h2>
+  <p>If your team is looking for an industrial salt exporter, the first step is to align the required grade against the actual end use before quotation begins.</p>
+  <ul class="bullet-list">
+    <li>Current portfolio includes industrial salt, raw salt, crystalline salt, de-icing salt, and iodized grades</li><li>Commercial discussion is aligned to grade, purity direction, and shipment basis together</li><li>Packing and dispatch planning are handled in the same conversation as the grade discussion</li>
+  </ul>
+</section><section class="blog-article-section" data-reveal>
+  <h2>Where the salt line is used</h2>
+  <p>Salt requirements shift by application, so buyers usually need grade direction and iodine basis settled before the offer is finalized.</p>
+  <ul class="bullet-list">
+    <li>Chemical and industrial processing</li><li>Water treatment applications</li><li>De-icing and utility use</li><li>Food processing and commercial supply</li>
+  </ul>
+</section><section class="blog-article-section" data-reveal>
+  <h2>Quality focus before quotation</h2>
+  <p>Technical and commercial alignment matter most when buyers want the same grade basis to hold through trial and repeat shipments.</p>
+  <ul class="bullet-list">
+    <li>Required salt grade is aligned first</li><li>NaCl purity, iodine requirement, and grain size are reviewed against end use</li><li>Packing and monthly volume are handled with the quality discussion</li>
+  </ul>
+</section><section class="blog-article-section" data-reveal>
+  <h2>Supply and export setup</h2>
+  <p>The order moves more cleanly when sample basis, document flow, and shipment plan are aligned before cargo planning starts.</p>
+  <ul class="bullet-list">
+    <li>Packing: 50 Kg bags and jumbo bags</li><li>Shipment mode: FCL</li><li>Export handling includes sample alignment, document alignment, and shipment planning from India based on destination and order size</li>
+  </ul>
+</section>
+                </article>
+                <aside class="blog-sidecard" data-reveal>
+                  <p class="section-label">Buyer RFQ checklist</p>
+                  <h2>Share these details in your first inquiry.</h2>
+                  <ul class="bullet-list">
+                    <li>Required grade and end use</li><li>NaCl purity and iodine requirement</li><li>Required grain size and packing basis</li><li>Trial quantity and expected monthly volume</li><li>Destination port and delivery timing</li>
+                  </ul>
+                  <div class="related-links blog-sidecard__links">
+                    <a href="/products/salt/">Open Salt</a>
+                    <a href="/operations/">See operations</a>
+                    <a href="/#contact" data-set-request="Quote">Send inquiry</a>
+                  </div>
+                </aside>
+              </div>
+            </div>
+          </section>
+
+          <section class="section-block section-block--contrast">
+            <div class="shell section-shell">
+              <div class="section-topline section-topline--stack" data-reveal>
+                <div class="section-topline__copy">
+                  <p class="section-kicker">Related guides</p>
+                  <h2>Continue with nearby buyer questions.</h2>
+                </div>
+                <a class="section-link" href="/blog/">Open all guides</a>
+              </div>
+              <div class="blog-grid blog-grid--compact">
+                <a class="blog-card blog-card--compact" href="/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" data-reveal>
+  <p class="blog-card__eyebrow">Quartz Sand / Vietnam / Ceramics-Glass</p>
+  <h3>Quartz Sand Supplier from India: Buyer Checklist for Vietnam Ceramics and Glass Teams</h3>
+  <p>What import buyers should confirm before RFQ when sourcing quartz sand, grits, and powder from India.</p>
+</a><a class="blog-card blog-card--compact" href="/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" data-reveal>
+  <p class="blog-card__eyebrow">Feldspar / Ceramics-Glass / Import Guide</p>
+  <h3>Potassium vs Sodium Feldspar: What Import Buyers Should Confirm Before Buying</h3>
+  <p>How buyers compare potash and soda feldspar grades for ceramic and glass applications before quote.</p>
+</a><a class="blog-card blog-card--compact" href="/blog/silica-sand-import-checklist-glass-foundry-filtration/" data-reveal>
+  <p class="blog-card__eyebrow">Silica Sand / Buyer Checklist</p>
+  <h3>Silica Sand Import Checklist for Glass, Foundry, and Filtration Buyers</h3>
+  <p>A practical import checklist for buyers comparing silica sand suppliers and preparing a clean RFQ.</p>
+</a>
+              </div>
+            </div>
+          </section>
+        </main>
+        <footer class="site-footer">
+  <div class="shell site-footer__inner">
+    <div>
+      <p class="footer-label">Jade Waves Enterprise</p>
+      <p class="footer-copy">Industrial minerals, supplied with more control.</p>
+    </div>
+    <div class="footer-grid">
+      <div>
+        <p class="footer-heading">Contact</p>
+        <a href="tel:+91-999-883-5503">+91-999-883-5503</a>
+        <a href="mailto:deep@jadewavesenterprise.com">deep@jadewavesenterprise.com</a>
+      </div>
+      <div>
+        <p class="footer-heading">Navigate</p>
+        <a href="/">Home</a>
+        <a href="/products/">Products</a>
+        <a href="/operations/">Operations</a>
+        <a href="/blog/">Blog</a>
+        <a href="/hear-from-ceo/">Hear from Our CEO</a>
+        <a href="/export-markets/">Export Markets</a>
+        <a href="/#contact">Contact</a>
+      </div>
+    </div>
+  </div>
+  <div class="shell site-footer__meta">
+    <p>&copy; <span data-current-year>2026</span> Jade Waves Enterprise. All rights reserved.</p>
+  </div>
+</footer>
+              </body>
+            </html>

--- a/blog/industrial-salt-import-guide-gulf-buyers/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/index.html
@@ -1,22 +1,195 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Blog Redirect | Jade Waves Enterprise</title>
-    <meta name="description" content="This article has been consolidated into the current Jade Waves content hub." />
-    <meta name="robots" content="noindex,follow" />
-    <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
-    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
-    <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>
-    <link rel="stylesheet" href="/styles.css" />
-  </head>
-  <body class="antialiased page-redirect">
-    <main class="shell" style="padding: 6rem 1.5rem;">
-      <p class="section-label">Redirecting</p>
-      <h1>Blog Redirect | Jade Waves Enterprise</h1>
-      <p>This article has been consolidated into the current Jade Waves content hub.</p>
-      <p><a href="/blog/">Continue to the current page</a></p>
-    </main>
-  </body>
-</html>
+            <html lang="en">
+              <head>
+                <meta charset="UTF-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                <title>Industrial Salt Import Guide for Gulf Buyers | Jade Waves Enterprise</title>
+                <meta name="description" content="Industrial salt import guide for UAE, Oman, Qatar, and Kuwait buyers covering grades, packing, and shipment planning." />
+                <meta name="robots" content="index,follow" />
+                <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
+                <meta property="og:title" content="Industrial Salt Import Guide for Gulf Buyers | Jade Waves Enterprise" />
+                <meta property="og:description" content="Industrial salt import guide for UAE, Oman, Qatar, and Kuwait buyers covering grades, packing, and shipment planning." />
+                <meta property="og:type" content="website" />
+                <meta property="og:url" content="https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
+                <meta property="og:site_name" content="Jade Waves Enterprise" />
+                <meta property="og:image" content="https://jadewavesenterprise.com/assets/jade-waves-logo-transparent.png" />
+                <link rel="preconnect" href="https://fonts.googleapis.com" />
+                <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+                <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+                <link rel="stylesheet" href="/styles.css" />
+                <script async src="https://www.googletagmanager.com/gtag/js?id=G-9BRL4JKNN6"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-9BRL4JKNN6');
+</script>
+                <script type="application/ld+json">[{"@context": "https://schema.org", "@type": "BlogPosting", "headline": "Industrial Salt Import Guide for UAE, Oman, Qatar, and Kuwait Buyers", "description": "Industrial salt import guide for UAE, Oman, Qatar, and Kuwait buyers covering grades, packing, and shipment planning.", "mainEntityOfPage": "https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/", "url": "https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/", "datePublished": "2026-04-30", "dateModified": "2026-04-30", "author": {"@type": "Organization", "name": "Jade Waves Enterprise"}, "publisher": {"@type": "Organization", "name": "Jade Waves Enterprise", "logo": {"@type": "ImageObject", "url": "https://jadewavesenterprise.com/assets/jade-waves-logo-transparent.png"}}}, {"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "Home", "item": "https://jadewavesenterprise.com"}, {"@type": "ListItem", "position": 2, "name": "Blog", "item": "https://jadewavesenterprise.com/blog/"}, {"@type": "ListItem", "position": 3, "name": "Industrial Salt Import Guide for UAE, Oman, Qatar, and Kuwait Buyers", "item": "https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/"}]}]</script>
+                <script defer src="/script.js"></script>
+              </head>
+              <body class="antialiased page-blog-post">
+                <header class="site-header" data-header>
+  <div class="site-header__inner">
+    <a class="brand-mark" href="/" aria-label="Jade Waves Enterprise home">
+      <img src="/assets/jade-waves-logo-transparent.png" alt="Jade Waves Enterprise logo" />
+    </a>
+    <nav class="desktop-nav" aria-label="Primary">
+      <a href="/#about">About</a>
+      <a href="/products/">Products</a>
+      <a href="/operations/">Operations</a>
+      <a href="/blog/">Blog</a>
+      <a href="/export-markets/">Markets</a>
+      <a href="/#contact">Contact</a>
+    </nav>
+    <div class="header-actions">
+      <a class="button button--dark button--compact" href="/#contact" data-set-request="Quote">Request Quote</a>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu" data-menu-toggle>
+        Menu
+      </button>
+    </div>
+  </div>
+  <div class="mobile-menu" id="mobile-menu" data-mobile-menu hidden>
+    <a href="/#about">About</a>
+    <a href="/products/">Products</a>
+    <a href="/operations/">Operations</a>
+    <a href="/blog/">Blog</a>
+    <a href="/export-markets/">Markets</a>
+    <a href="/#contact">Contact</a>
+  </div>
+</header>
+        <main>
+          <section class="hero hero--home">
+            <div class="hero__strata" aria-hidden="true">
+              <span class="strata strata--a"></span>
+              <span class="strata strata--b"></span>
+              <span class="strata strata--c"></span>
+              <span class="route-line route-line--hero"></span>
+            </div>
+            <div class="shell home-hero">
+              <div class="hero-copy hero-copy--home" data-reveal>
+                <p class="hero-label">Salt / Gulf Importers</p>
+                <h1>Industrial Salt Import Guide for UAE, Oman, Qatar, and Kuwait Buyers</h1>
+                <p class="hero-text">A buyer-side guide for industrial salt sourcing from India with packaging and dispatch clarity.</p>
+                <div class="hero-actions">
+                  <a class="button button--light" href="/products/salt/">Open Salt</a>
+                  <a class="button button--ghost" href="/#contact" data-set-request="Quote">Request Quote</a>
+                </div>
+              </div>
+            </div>
+            <div class="shell proof-strip" data-reveal>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">From this guide</span>
+                <strong>What to confirm before RFQ</strong>
+              </article>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">Primary product</span>
+                <strong>Salt</strong>
+              </article>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">Move to technicals</span>
+                <strong><a href="/products/salt/">Open product page</a></strong>
+              </article>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">Move to inquiry</span>
+                <strong><a href="/#contact" data-set-request="Quote">Send requirement</a></strong>
+              </article>
+            </div>
+          </section>
+
+          <section class="section-block">
+            <div class="shell section-shell">
+              <div class="blog-layout">
+                <article class="blog-article">
+                  <section class="blog-article-section" data-reveal>
+  <h2>Select grade by process requirement</h2>
+  <p>Industrial salt inquiries work best when application context is shared first.</p>
+  <ul class="bullet-list">
+    <li>Clarify if requirement is chemical processing, treatment, or utility use.</li><li>Share grade preference and acceptance range.</li><li>Align crystal size with process handling setup.</li>
+  </ul>
+</section><section class="blog-article-section" data-reveal>
+  <h2>Avoid confusion in RFQ language</h2>
+  <p>Using generic salt terms creates back-and-forth that delays purchasing cycles.</p>
+  <ul class="bullet-list">
+    <li>Use clear grade name and packing basis in RFQ.</li><li>Include destination and shipment term expectation.</li><li>Mention monthly or project volume range for practical quote.</li>
+  </ul>
+</section><section class="blog-article-section" data-reveal>
+  <h2>Treat logistics as part of product quality</h2>
+  <p>Packing integrity and dispatch consistency directly affect usable material at destination.</p>
+  <ul class="bullet-list">
+    <li>Confirm packing protection for transit conditions.</li><li>Align loading plan to receiving infrastructure.</li><li>Ensure document set is finalized before vessel planning.</li>
+  </ul>
+</section>
+                </article>
+                <aside class="blog-sidecard" data-reveal>
+                  <p class="section-label">Buyer RFQ checklist</p>
+                  <h2>Share these details in your first inquiry.</h2>
+                  <ul class="bullet-list">
+                    <li>Which salt grade is best for our end use?</li><li>Can you support our packing and unloading format?</li><li>What documents are supplied with each shipment?</li><li>What lead time should we plan for repeat orders?</li>
+                  </ul>
+                  <div class="related-links blog-sidecard__links">
+                    <a href="/products/salt/">Open Salt</a>
+                    <a href="/operations/">See operations</a>
+                    <a href="/#contact" data-set-request="Quote">Send inquiry</a>
+                  </div>
+                </aside>
+              </div>
+            </div>
+          </section>
+
+          <section class="section-block section-block--contrast">
+            <div class="shell section-shell">
+              <div class="section-topline section-topline--stack" data-reveal>
+                <div class="section-topline__copy">
+                  <p class="section-kicker">Related guides</p>
+                  <h2>Continue with nearby buyer questions.</h2>
+                </div>
+                <a class="section-link" href="/blog/">Open all guides</a>
+              </div>
+              <div class="blog-grid blog-grid--compact">
+                <a class="blog-card blog-card--compact" href="/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" data-reveal>
+  <p class="blog-card__eyebrow">Quartz Sand / Vietnam / Ceramics-Glass</p>
+  <h3>Quartz Sand Supplier from India: Buyer Checklist for Vietnam Ceramics and Glass Teams</h3>
+  <p>What import buyers should confirm before RFQ when sourcing quartz sand, grits, and powder from India.</p>
+</a><a class="blog-card blog-card--compact" href="/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" data-reveal>
+  <p class="blog-card__eyebrow">Feldspar / Ceramics-Glass / Import Guide</p>
+  <h3>Potassium vs Sodium Feldspar: What Import Buyers Should Confirm Before Buying</h3>
+  <p>How buyers compare potash and soda feldspar grades for ceramic and glass applications before quote.</p>
+</a><a class="blog-card blog-card--compact" href="/blog/silica-sand-import-checklist-glass-foundry-filtration/" data-reveal>
+  <p class="blog-card__eyebrow">Silica Sand / Buyer Checklist</p>
+  <h3>Silica Sand Import Checklist for Glass, Foundry, and Filtration Buyers</h3>
+  <p>A practical import checklist for buyers comparing silica sand suppliers and preparing a clean RFQ.</p>
+</a>
+              </div>
+            </div>
+          </section>
+        </main>
+        <footer class="site-footer">
+  <div class="shell site-footer__inner">
+    <div>
+      <p class="footer-label">Jade Waves Enterprise</p>
+      <p class="footer-copy">Industrial minerals, supplied with more control.</p>
+    </div>
+    <div class="footer-grid">
+      <div>
+        <p class="footer-heading">Contact</p>
+        <a href="tel:+91-999-883-5503">+91-999-883-5503</a>
+        <a href="mailto:deep@jadewavesenterprise.com">deep@jadewavesenterprise.com</a>
+      </div>
+      <div>
+        <p class="footer-heading">Navigate</p>
+        <a href="/">Home</a>
+        <a href="/products/">Products</a>
+        <a href="/operations/">Operations</a>
+        <a href="/blog/">Blog</a>
+        <a href="/hear-from-ceo/">Hear from Our CEO</a>
+        <a href="/export-markets/">Export Markets</a>
+        <a href="/#contact">Contact</a>
+      </div>
+    </div>
+  </div>
+  <div class="shell site-footer__meta">
+    <p>&copy; <span data-current-year>2026</span> Jade Waves Enterprise. All rights reserved.</p>
+  </div>
+</footer>
+              </body>
+            </html>

--- a/blog/kaolin-supplier-for-paint-industry/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/index.html
@@ -1,22 +1,201 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Blog Redirect | Jade Waves Enterprise</title>
-    <meta name="description" content="This article has been consolidated into the current Jade Waves content hub." />
-    <meta name="robots" content="noindex,follow" />
-    <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
-    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
-    <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>
-    <link rel="stylesheet" href="/styles.css" />
-  </head>
-  <body class="antialiased page-redirect">
-    <main class="shell" style="padding: 6rem 1.5rem;">
-      <p class="section-label">Redirecting</p>
-      <h1>Blog Redirect | Jade Waves Enterprise</h1>
-      <p>This article has been consolidated into the current Jade Waves content hub.</p>
-      <p><a href="/blog/">Continue to the current page</a></p>
-    </main>
-  </body>
-</html>
+            <html lang="en">
+              <head>
+                <meta charset="UTF-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                <title>Kaolin Supplier for Paint Industry | Forms, Brightness Focus, Export Supply</title>
+                <meta name="description" content="Kaolin supply for paint industry buyers with forms, quality focus points, and export handling support from India." />
+                <meta name="robots" content="index,follow" />
+                <link rel="canonical" href="https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
+                <meta property="og:title" content="Kaolin Supplier for Paint Industry | Forms, Brightness Focus, Export Supply" />
+                <meta property="og:description" content="Kaolin supply for paint industry buyers with forms, quality focus points, and export handling support from India." />
+                <meta property="og:type" content="website" />
+                <meta property="og:url" content="https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
+                <meta property="og:site_name" content="Jade Waves Enterprise" />
+                <meta property="og:image" content="https://jadewavesenterprise.com/assets/jade-waves-logo-transparent.png" />
+                <link rel="preconnect" href="https://fonts.googleapis.com" />
+                <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+                <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+                <link rel="stylesheet" href="/styles.css" />
+                <script async src="https://www.googletagmanager.com/gtag/js?id=G-9BRL4JKNN6"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-9BRL4JKNN6');
+</script>
+                <script type="application/ld+json">[{"@context": "https://schema.org", "@type": "BlogPosting", "headline": "Kaolin Supplier for Paint Industry: What We Supply", "description": "Kaolin supply for paint industry buyers with forms, quality focus points, and export handling support from India.", "mainEntityOfPage": "https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/", "url": "https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/", "datePublished": "2026-04-30", "dateModified": "2026-04-30", "author": {"@type": "Organization", "name": "Jade Waves Enterprise"}, "publisher": {"@type": "Organization", "name": "Jade Waves Enterprise", "logo": {"@type": "ImageObject", "url": "https://jadewavesenterprise.com/assets/jade-waves-logo-transparent.png"}}}, {"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "Home", "item": "https://jadewavesenterprise.com"}, {"@type": "ListItem", "position": 2, "name": "Blog", "item": "https://jadewavesenterprise.com/blog/"}, {"@type": "ListItem", "position": 3, "name": "Kaolin Supplier for Paint Industry: What We Supply", "item": "https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/"}]}]</script>
+                <script defer src="/script.js"></script>
+              </head>
+              <body class="antialiased page-blog-post">
+                <header class="site-header" data-header>
+  <div class="site-header__inner">
+    <a class="brand-mark" href="/" aria-label="Jade Waves Enterprise home">
+      <img src="/assets/jade-waves-logo-transparent.png" alt="Jade Waves Enterprise logo" />
+    </a>
+    <nav class="desktop-nav" aria-label="Primary">
+      <a href="/#about">About</a>
+      <a href="/products/">Products</a>
+      <a href="/operations/">Operations</a>
+      <a href="/blog/">Blog</a>
+      <a href="/export-markets/">Markets</a>
+      <a href="/#contact">Contact</a>
+    </nav>
+    <div class="header-actions">
+      <a class="button button--dark button--compact" href="/#contact" data-set-request="Quote">Request Quote</a>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu" data-menu-toggle>
+        Menu
+      </button>
+    </div>
+  </div>
+  <div class="mobile-menu" id="mobile-menu" data-mobile-menu hidden>
+    <a href="/#about">About</a>
+    <a href="/products/">Products</a>
+    <a href="/operations/">Operations</a>
+    <a href="/blog/">Blog</a>
+    <a href="/export-markets/">Markets</a>
+    <a href="/#contact">Contact</a>
+  </div>
+</header>
+        <main>
+          <section class="hero hero--home">
+            <div class="hero__strata" aria-hidden="true">
+              <span class="strata strata--a"></span>
+              <span class="strata strata--b"></span>
+              <span class="strata strata--c"></span>
+              <span class="route-line route-line--hero"></span>
+            </div>
+            <div class="shell home-hero">
+              <div class="hero-copy hero-copy--home" data-reveal>
+                <p class="hero-label">Kaolin / Paint Industry</p>
+                <h1>Kaolin Supplier for Paint Industry: What We Supply</h1>
+                <p class="hero-text">A direct kaolin supply guide for paint and coatings buyers reviewing forms, brightness focus, and export handling from India.</p>
+                <div class="hero-actions">
+                  <a class="button button--light" href="/products/kaolin--china-clay/">Open Kaolin (China Clay)</a>
+                  <a class="button button--ghost" href="/#contact" data-set-request="Quote">Request Quote</a>
+                </div>
+              </div>
+            </div>
+            <div class="shell proof-strip" data-reveal>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">From this guide</span>
+                <strong>What to confirm before RFQ</strong>
+              </article>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">Primary product</span>
+                <strong>Kaolin (China Clay)</strong>
+              </article>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">Move to technicals</span>
+                <strong><a href="/products/kaolin--china-clay/">Open product page</a></strong>
+              </article>
+              <article class="proof-strip__item">
+                <span class="proof-strip__eyebrow">Move to inquiry</span>
+                <strong><a href="/#contact" data-set-request="Quote">Send requirement</a></strong>
+              </article>
+            </div>
+          </section>
+
+          <section class="section-block">
+            <div class="shell section-shell">
+              <div class="blog-layout">
+                <article class="blog-article">
+                  <section class="blog-article-section" data-reveal>
+  <h2>What we offer</h2>
+  <p>If your team is sourcing kaolin for paint industry use, the first step is to align the form, brightness direction, and shipment basis before quotation starts.</p>
+  <ul class="bullet-list">
+    <li>Current supply forms include lumps and powder</li><li>Paint and coatings discussions are aligned to application before commercial offer</li><li>Packing and shipment planning are handled together with the grade conversation</li>
+  </ul>
+</section><section class="blog-article-section" data-reveal>
+  <h2>Where the kaolin line is used</h2>
+  <p>Kaolin requirements change by end use, so paint buyers usually need cleaner alignment on performance and impurity expectations early.</p>
+  <ul class="bullet-list">
+    <li>Paints and coatings</li><li>Ceramics and tiles</li><li>Paper systems</li><li>Rubber and industrial fillers</li>
+  </ul>
+</section><section class="blog-article-section" data-reveal>
+  <h2>Quality focus before quotation</h2>
+  <p>Technical alignment helps paint-industry buyers avoid trial drift between the sample basis and repeat supply basis.</p>
+  <ul class="bullet-list">
+    <li>Brightness target and Fe2O3 limit are aligned first</li><li>Al2O3 and SiO2 profile are reviewed against application need</li><li>Form, packing, and order volume are handled with the quality discussion</li>
+  </ul>
+</section><section class="blog-article-section" data-reveal>
+  <h2>Supply and export setup</h2>
+  <p>The material fit matters, but the shipment basis needs to stay equally clear when import planning starts.</p>
+  <ul class="bullet-list">
+    <li>Packing: 50 Kg bags and jumbo bags</li><li>Shipment mode: FCL</li><li>Export handling includes sample alignment, document alignment, and shipment planning from India based on destination and order size</li>
+  </ul>
+</section>
+                </article>
+                <aside class="blog-sidecard" data-reveal>
+                  <p class="section-label">Buyer RFQ checklist</p>
+                  <h2>Share these details in your first inquiry.</h2>
+                  <ul class="bullet-list">
+                    <li>Paint or coating application and process context</li><li>Required brightness, whiteness, and impurity limits</li><li>Preferred form: lumps or powder</li><li>Trial quantity and expected monthly volume</li><li>Destination port and preferred packing basis</li>
+                  </ul>
+                  <div class="related-links blog-sidecard__links">
+                    <a href="/products/kaolin--china-clay/">Open Kaolin (China Clay)</a>
+                    <a href="/operations/">See operations</a>
+                    <a href="/#contact" data-set-request="Quote">Send inquiry</a>
+                  </div>
+                </aside>
+              </div>
+            </div>
+          </section>
+
+          <section class="section-block section-block--contrast">
+            <div class="shell section-shell">
+              <div class="section-topline section-topline--stack" data-reveal>
+                <div class="section-topline__copy">
+                  <p class="section-kicker">Related guides</p>
+                  <h2>Continue with nearby buyer questions.</h2>
+                </div>
+                <a class="section-link" href="/blog/">Open all guides</a>
+              </div>
+              <div class="blog-grid blog-grid--compact">
+                <a class="blog-card blog-card--compact" href="/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" data-reveal>
+  <p class="blog-card__eyebrow">Quartz Sand / Vietnam / Ceramics-Glass</p>
+  <h3>Quartz Sand Supplier from India: Buyer Checklist for Vietnam Ceramics and Glass Teams</h3>
+  <p>What import buyers should confirm before RFQ when sourcing quartz sand, grits, and powder from India.</p>
+</a><a class="blog-card blog-card--compact" href="/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" data-reveal>
+  <p class="blog-card__eyebrow">Feldspar / Ceramics-Glass / Import Guide</p>
+  <h3>Potassium vs Sodium Feldspar: What Import Buyers Should Confirm Before Buying</h3>
+  <p>How buyers compare potash and soda feldspar grades for ceramic and glass applications before quote.</p>
+</a><a class="blog-card blog-card--compact" href="/blog/silica-sand-import-checklist-glass-foundry-filtration/" data-reveal>
+  <p class="blog-card__eyebrow">Silica Sand / Buyer Checklist</p>
+  <h3>Silica Sand Import Checklist for Glass, Foundry, and Filtration Buyers</h3>
+  <p>A practical import checklist for buyers comparing silica sand suppliers and preparing a clean RFQ.</p>
+</a>
+              </div>
+            </div>
+          </section>
+        </main>
+        <footer class="site-footer">
+  <div class="shell site-footer__inner">
+    <div>
+      <p class="footer-label">Jade Waves Enterprise</p>
+      <p class="footer-copy">Industrial minerals, supplied with more control.</p>
+    </div>
+    <div class="footer-grid">
+      <div>
+        <p class="footer-heading">Contact</p>
+        <a href="tel:+91-999-883-5503">+91-999-883-5503</a>
+        <a href="mailto:deep@jadewavesenterprise.com">deep@jadewavesenterprise.com</a>
+      </div>
+      <div>
+        <p class="footer-heading">Navigate</p>
+        <a href="/">Home</a>
+        <a href="/products/">Products</a>
+        <a href="/operations/">Operations</a>
+        <a href="/blog/">Blog</a>
+        <a href="/hear-from-ceo/">Hear from Our CEO</a>
+        <a href="/export-markets/">Export Markets</a>
+        <a href="/#contact">Contact</a>
+      </div>
+    </div>
+  </div>
+  <div class="shell site-footer__meta">
+    <p>&copy; <span data-current-year>2026</span> Jade Waves Enterprise. All rights reserved.</p>
+  </div>
+</footer>
+              </body>
+            </html>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
@@ -154,10 +154,10 @@
   <p class="blog-card__eyebrow">Silica Sand / Buyer Checklist</p>
   <h3>Silica Sand Import Checklist for Glass, Foundry, and Filtration Buyers</h3>
   <p>A practical import checklist for buyers comparing silica sand suppliers and preparing a clean RFQ.</p>
-</a><a class="blog-card blog-card--compact" href="/blog/potassium-feldspar-supplier-for-ceramic-tiles/" data-reveal>
-  <p class="blog-card__eyebrow">Potassium Feldspar / Ceramic Tiles</p>
-  <h3>Potassium Feldspar Supplier for Ceramic Tiles: Export-Ready Supply for Manufacturers</h3>
-  <p>A direct buyer guide for ceramic tile manufacturers reviewing potassium feldspar grade fit, particle size alignment, and export handling from India.</p>
+</a><a class="blog-card blog-card--compact" href="/blog/bentonite-grade-selection-guide-for-importers/" data-reveal>
+  <p class="blog-card__eyebrow">Bentonite / Grade Selection</p>
+  <h3>Bentonite Grade Selection Guide for Drilling, Foundry, and Civil Buyers</h3>
+  <p>How buyers shortlist bentonite grades by application and avoid mismatched trials.</p>
 </a>
               </div>
             </div>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
@@ -154,10 +154,10 @@
   <p class="blog-card__eyebrow">Silica Sand / Buyer Checklist</p>
   <h3>Silica Sand Import Checklist for Glass, Foundry, and Filtration Buyers</h3>
   <p>A practical import checklist for buyers comparing silica sand suppliers and preparing a clean RFQ.</p>
-</a><a class="blog-card blog-card--compact" href="/blog/potassium-feldspar-supplier-for-ceramic-tiles/" data-reveal>
-  <p class="blog-card__eyebrow">Potassium Feldspar / Ceramic Tiles</p>
-  <h3>Potassium Feldspar Supplier for Ceramic Tiles: Export-Ready Supply for Manufacturers</h3>
-  <p>A direct buyer guide for ceramic tile manufacturers reviewing potassium feldspar grade fit, particle size alignment, and export handling from India.</p>
+</a><a class="blog-card blog-card--compact" href="/blog/bentonite-grade-selection-guide-for-importers/" data-reveal>
+  <p class="blog-card__eyebrow">Bentonite / Grade Selection</p>
+  <h3>Bentonite Grade Selection Guide for Drilling, Foundry, and Civil Buyers</h3>
+  <p>How buyers shortlist bentonite grades by application and avoid mismatched trials.</p>
 </a>
               </div>
             </div>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
@@ -154,10 +154,10 @@
   <p class="blog-card__eyebrow">Feldspar / Ceramics-Glass / Import Guide</p>
   <h3>Potassium vs Sodium Feldspar: What Import Buyers Should Confirm Before Buying</h3>
   <p>How buyers compare potash and soda feldspar grades for ceramic and glass applications before quote.</p>
-</a><a class="blog-card blog-card--compact" href="/blog/potassium-feldspar-supplier-for-ceramic-tiles/" data-reveal>
-  <p class="blog-card__eyebrow">Potassium Feldspar / Ceramic Tiles</p>
-  <h3>Potassium Feldspar Supplier for Ceramic Tiles: Export-Ready Supply for Manufacturers</h3>
-  <p>A direct buyer guide for ceramic tile manufacturers reviewing potassium feldspar grade fit, particle size alignment, and export handling from India.</p>
+</a><a class="blog-card blog-card--compact" href="/blog/bentonite-grade-selection-guide-for-importers/" data-reveal>
+  <p class="blog-card__eyebrow">Bentonite / Grade Selection</p>
+  <h3>Bentonite Grade Selection Guide for Drilling, Foundry, and Civil Buyers</h3>
+  <p>How buyers shortlist bentonite grades by application and avoid mismatched trials.</p>
 </a>
               </div>
             </div>

--- a/blogs/f/activated-bleaching-earth/index.html
+++ b/blogs/f/activated-bleaching-earth/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Activated bleaching earth moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Activated bleaching earth article moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
-    <meta http-equiv="refresh" content="0; url=/products/" />
-    <script>window.location.replace("/products/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Activated bleaching earth moved to <a href="/products/">https://jadewavesenterprise.com/products/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Activated bleaching earth article moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/blogs/f/bentonite-clay-and-its-applications/index.html
+++ b/blogs/f/bentonite-clay-and-its-applications/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Bentonite applications article moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Bentonite applications article moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
-    <meta http-equiv="refresh" content="0; url=/products/bentonite/" />
-    <script>window.location.replace("/products/bentonite/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Bentonite applications article moved to <a href="/products/bentonite/">https://jadewavesenterprise.com/products/bentonite/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Bentonite applications article moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/bentonite/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/blogs/f/bentonite-suppliers-in-malaysia/index.html
+++ b/blogs/f/bentonite-suppliers-in-malaysia/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Bentonite suppliers in Malaysia moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Bentonite Malaysia article moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
-    <meta http-equiv="refresh" content="0; url=/products/bentonite/" />
-    <script>window.location.replace("/products/bentonite/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Bentonite suppliers in Malaysia moved to <a href="/products/bentonite/">https://jadewavesenterprise.com/products/bentonite/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Bentonite Malaysia article moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/bentonite/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/blogs/f/bentonite-suppliers-in-saudi-arabia/index.html
+++ b/blogs/f/bentonite-suppliers-in-saudi-arabia/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Bentonite Suppliers in Saudi Arabia moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Bentonite Saudi Arabia article moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
-    <meta http-equiv="refresh" content="0; url=/products/bentonite/" />
-    <script>window.location.replace("/products/bentonite/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Bentonite Suppliers in Saudi Arabia moved to <a href="/products/bentonite/">https://jadewavesenterprise.com/products/bentonite/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Bentonite Saudi Arabia article moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/bentonite/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/blogs/f/bentonite-suppliers-in-vietnam/index.html
+++ b/blogs/f/bentonite-suppliers-in-vietnam/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Bentonite suppliers in Vietnam moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Bentonite Vietnam article moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
-    <meta http-equiv="refresh" content="0; url=/products/bentonite/" />
-    <script>window.location.replace("/products/bentonite/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Bentonite suppliers in Vietnam moved to <a href="/products/bentonite/">https://jadewavesenterprise.com/products/bentonite/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Bentonite Vietnam article moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/bentonite/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/blogs/f/copper-slag-for-sandblasting/index.html
+++ b/blogs/f/copper-slag-for-sandblasting/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Copper slag sandblasting article moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Copper slag sandblasting article moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
-    <meta http-equiv="refresh" content="0; url=/blog/copper-slag-supplier-for-shipyard-blasting/" />
-    <script>window.location.replace("/blog/copper-slag-supplier-for-shipyard-blasting/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Copper slag sandblasting article moved to <a href="/blog/copper-slag-supplier-for-shipyard-blasting/">https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Copper slag sandblasting article moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/blog/copper-slag-supplier-for-shipyard-blasting/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/blogs/f/copper-slag-suppliers-in-india/index.html
+++ b/blogs/f/copper-slag-suppliers-in-india/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Copper slag suppliers in India moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Copper slag supplier article moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
-    <meta http-equiv="refresh" content="0; url=/products/copper-slag/" />
-    <script>window.location.replace("/products/copper-slag/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Copper slag suppliers in India moved to <a href="/products/copper-slag/">https://jadewavesenterprise.com/products/copper-slag/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Copper slag supplier article moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/copper-slag/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/blogs/f/drilling-bentonite/index.html
+++ b/blogs/f/drilling-bentonite/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Drilling bentonite article moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Drilling bentonite article moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
-    <meta http-equiv="refresh" content="0; url=/products/bentonite/" />
-    <script>window.location.replace("/products/bentonite/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Drilling bentonite article moved to <a href="/products/bentonite/">https://jadewavesenterprise.com/products/bentonite/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Drilling bentonite article moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/bentonite/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/blogs/f/fly-ash-suppliers-in-india/index.html
+++ b/blogs/f/fly-ash-suppliers-in-india/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Fly ash suppliers in India moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Fly ash supplier article moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
-    <meta http-equiv="refresh" content="0; url=/blog/fly-ash-exporter-from-india-bulk-shipment/" />
-    <script>window.location.replace("/blog/fly-ash-exporter-from-india-bulk-shipment/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Fly ash suppliers in India moved to <a href="/blog/fly-ash-exporter-from-india-bulk-shipment/">https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Fly ash supplier article moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/blog/fly-ash-exporter-from-india-bulk-shipment/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/blogs/f/innovations-in-recycling-fly-ash/index.html
+++ b/blogs/f/innovations-in-recycling-fly-ash/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Fly ash recycling article moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Fly ash recycling article moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
-    <meta http-equiv="refresh" content="0; url=/blog/fly-ash-exporter-from-india-bulk-shipment/" />
-    <script>window.location.replace("/blog/fly-ash-exporter-from-india-bulk-shipment/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Fly ash recycling article moved to <a href="/blog/fly-ash-exporter-from-india-bulk-shipment/">https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Fly ash recycling article moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/blog/fly-ash-exporter-from-india-bulk-shipment/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/blogs/f/kaolin-china-clay-suppliers-in-india/index.html
+++ b/blogs/f/kaolin-china-clay-suppliers-in-india/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Kaolin suppliers in India moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Kaolin article moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
-    <meta http-equiv="refresh" content="0; url=/products/kaolin--china-clay/" />
-    <script>window.location.replace("/products/kaolin--china-clay/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Kaolin suppliers in India moved to <a href="/products/kaolin--china-clay/">https://jadewavesenterprise.com/products/kaolin--china-clay/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Kaolin article moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/kaolin--china-clay/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/blogs/f/paint-bentonite/index.html
+++ b/blogs/f/paint-bentonite/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Paint bentonite article moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Paint bentonite article moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
-    <meta http-equiv="refresh" content="0; url=/products/bentonite/" />
-    <script>window.location.replace("/products/bentonite/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Paint bentonite article moved to <a href="/products/bentonite/">https://jadewavesenterprise.com/products/bentonite/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Paint bentonite article moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/bentonite/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/blogs/f/potash-feldspar-feldspar-suppliers-india/index.html
+++ b/blogs/f/potash-feldspar-feldspar-suppliers-india/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Potash feldspar suppliers article moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Potash feldspar article moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
-    <meta http-equiv="refresh" content="0; url=/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
-    <script>window.location.replace("/blog/potassium-feldspar-supplier-for-ceramic-tiles/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Potash feldspar suppliers article moved to <a href="/blog/potassium-feldspar-supplier-for-ceramic-tiles/">https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Potash feldspar article moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/blog/potassium-feldspar-supplier-for-ceramic-tiles/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/blogs/f/quartz-supplier-in-vietnam---quartz-india/index.html
+++ b/blogs/f/quartz-supplier-in-vietnam---quartz-india/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Quartz supplier in Vietnam article moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Quartz Vietnam article moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
-    <meta http-equiv="refresh" content="0; url=/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
-    <script>window.location.replace("/blog/quartz-sand-supplier-india-vietnam-buyers-guide/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Quartz supplier in Vietnam article moved to <a href="/blog/quartz-sand-supplier-india-vietnam-buyers-guide/">https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Quartz Vietnam article moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/blog/quartz-sand-supplier-india-vietnam-buyers-guide/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/blogs/f/rubber-granules-maldives-rubber-granules-supplier-in-maldives/index.html
+++ b/blogs/f/rubber-granules-maldives-rubber-granules-supplier-in-maldives/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Rubber granules Maldives article moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Rubber granules article moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
-    <meta http-equiv="refresh" content="0; url=/products/" />
-    <script>window.location.replace("/products/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Rubber granules Maldives article moved to <a href="/products/">https://jadewavesenterprise.com/products/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Rubber granules article moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/blogs/f/salt-suppliers-in-mauritius-jade-waves-enterprise/index.html
+++ b/blogs/f/salt-suppliers-in-mauritius-jade-waves-enterprise/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Salt suppliers in Mauritius moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Salt Mauritius article moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
-    <meta http-equiv="refresh" content="0; url=/blog/industrial-salt-exporter/" />
-    <script>window.location.replace("/blog/industrial-salt-exporter/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-exporter/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Salt suppliers in Mauritius moved to <a href="/blog/industrial-salt-exporter/">https://jadewavesenterprise.com/blog/industrial-salt-exporter/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Salt Mauritius article moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/blog/industrial-salt-exporter/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/blogs/f/salt-suppliers-in-seychelles-jade-waves-enteprise/index.html
+++ b/blogs/f/salt-suppliers-in-seychelles-jade-waves-enteprise/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Salt suppliers in Seychelles moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Salt Seychelles article moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
-    <meta http-equiv="refresh" content="0; url=/blog/industrial-salt-exporter/" />
-    <script>window.location.replace("/blog/industrial-salt-exporter/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-exporter/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Salt suppliers in Seychelles moved to <a href="/blog/industrial-salt-exporter/">https://jadewavesenterprise.com/blog/industrial-salt-exporter/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Salt Seychelles article moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/blog/industrial-salt-exporter/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/blogs/f/salt-the-essential-mineral/index.html
+++ b/blogs/f/salt-the-essential-mineral/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Salt article moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Salt article moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
-    <meta http-equiv="refresh" content="0; url=/products/salt/" />
-    <script>window.location.replace("/products/salt/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Salt article moved to <a href="/products/salt/">https://jadewavesenterprise.com/products/salt/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Salt article moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/salt/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/blogs/f/silica-sand-for-artificial-football-turf/index.html
+++ b/blogs/f/silica-sand-for-artificial-football-turf/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Silica sand turf article moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Silica turf article moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
-    <meta http-equiv="refresh" content="0; url=/products/silica-sand/" />
-    <script>window.location.replace("/products/silica-sand/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Silica sand turf article moved to <a href="/products/silica-sand/">https://jadewavesenterprise.com/products/silica-sand/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Silica turf article moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/silica-sand/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/blogs/f/silica-sand-maldives/index.html
+++ b/blogs/f/silica-sand-maldives/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Silica Sand Maldives moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Silica sand Maldives article moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
-    <meta http-equiv="refresh" content="0; url=/products/silica-sand/" />
-    <script>window.location.replace("/products/silica-sand/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Silica Sand Maldives moved to <a href="/products/silica-sand/">https://jadewavesenterprise.com/products/silica-sand/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Silica sand Maldives article moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/silica-sand/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/blogs/f/silica-sand-suppliers-in-kenya/index.html
+++ b/blogs/f/silica-sand-suppliers-in-kenya/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Silica sand suppliers in Kenya moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Silica Kenya article moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
-    <meta http-equiv="refresh" content="0; url=/blog/silica-sand-exporter-from-india/" />
-    <script>window.location.replace("/blog/silica-sand-exporter-from-india/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Silica sand suppliers in Kenya moved to <a href="/blog/silica-sand-exporter-from-india/">https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Silica Kenya article moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/blog/silica-sand-exporter-from-india/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/blogs/f/silica-sand-suppliers-in-mauritius-jade-waves-enterprise/index.html
+++ b/blogs/f/silica-sand-suppliers-in-mauritius-jade-waves-enterprise/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Silica Sand Suppliers in Mauritius moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Silica Mauritius article moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
-    <meta http-equiv="refresh" content="0; url=/products/silica-sand/" />
-    <script>window.location.replace("/products/silica-sand/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Silica Sand Suppliers in Mauritius moved to <a href="/products/silica-sand/">https://jadewavesenterprise.com/products/silica-sand/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Silica Mauritius article moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/silica-sand/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/blogs/f/the-future-of-fly-ash-utilization-in-green-building-practices/index.html
+++ b/blogs/f/the-future-of-fly-ash-utilization-in-green-building-practices/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Fly ash green building article moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Fly ash green building article moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
-    <meta http-equiv="refresh" content="0; url=/blog/fly-ash-exporter-from-india-bulk-shipment/" />
-    <script>window.location.replace("/blog/fly-ash-exporter-from-india-bulk-shipment/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Fly ash green building article moved to <a href="/blog/fly-ash-exporter-from-india-bulk-shipment/">https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Fly ash green building article moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/blog/fly-ash-exporter-from-india-bulk-shipment/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/blogs/f/the-role-of-fly-ash-in-cement-manufacturing/index.html
+++ b/blogs/f/the-role-of-fly-ash-in-cement-manufacturing/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Fly ash cement article moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Fly ash cement article moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
-    <meta http-equiv="refresh" content="0; url=/blog/fly-ash-exporter-from-india-bulk-shipment/" />
-    <script>window.location.replace("/blog/fly-ash-exporter-from-india-bulk-shipment/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Fly ash cement article moved to <a href="/blog/fly-ash-exporter-from-india-bulk-shipment/">https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Fly ash cement article moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/blog/fly-ash-exporter-from-india-bulk-shipment/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/blogs/f/top-silica-sand-suppliers-in-india-jade-waves-enterprise/index.html
+++ b/blogs/f/top-silica-sand-suppliers-in-india-jade-waves-enterprise/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Silica sand suppliers article moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Silica suppliers article moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
-    <meta http-equiv="refresh" content="0; url=/blog/silica-sand-exporter-from-india/" />
-    <script>window.location.replace("/blog/silica-sand-exporter-from-india/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Silica sand suppliers article moved to <a href="/blog/silica-sand-exporter-from-india/">https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Silica suppliers article moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/blog/silica-sand-exporter-from-india/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/blogs/index.html
+++ b/blogs/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Blog index moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Blog index moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
-    <meta http-equiv="refresh" content="0; url=/blog/" />
-    <script>window.location.replace("/blog/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Blog index moved to <a href="/blog/">https://jadewavesenterprise.com/blog/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Blog index moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/blog/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/cat-litter-bentonite/index.html
+++ b/cat-litter-bentonite/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Cat litter bentonite page moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Cat litter bentonite moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
-    <meta http-equiv="refresh" content="0; url=/products/bentonite/" />
-    <script>window.location.replace("/products/bentonite/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Cat litter bentonite page moved to <a href="/products/bentonite/">https://jadewavesenterprise.com/products/bentonite/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Cat litter bentonite moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/bentonite/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/ceramics-bentonite/index.html
+++ b/ceramics-bentonite/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Ceramics bentonite page moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Ceramics bentonite moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
-    <meta http-equiv="refresh" content="0; url=/products/bentonite/" />
-    <script>window.location.replace("/products/bentonite/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Ceramics bentonite page moved to <a href="/products/bentonite/">https://jadewavesenterprise.com/products/bentonite/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Ceramics bentonite moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/bentonite/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/company-profile/index.html
+++ b/company-profile/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Company profile moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Company profile moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/industrial-minerals-exporter-india/" />
-    <meta http-equiv="refresh" content="0; url=/industrial-minerals-exporter-india/" />
-    <script>window.location.replace("/industrial-minerals-exporter-india/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/industrial-minerals-exporter-india/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/industrial-minerals-exporter-india/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Company profile moved to <a href="/industrial-minerals-exporter-india/">https://jadewavesenterprise.com/industrial-minerals-exporter-india/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Company profile moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/industrial-minerals-exporter-india/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/contact-1/index.html
+++ b/contact-1/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Contact moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Contact moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/#contact" />
-    <meta http-equiv="refresh" content="0; url=/#contact" />
-    <script>window.location.replace("/#contact");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/#contact" />
+    <script>window.location.replace("https://jadewavesenterprise.com/#contact");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Contact moved to <a href="/#contact">https://jadewavesenterprise.com/#contact</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Contact moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/#contact">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/contact-1/ola/services/business-collaboration/index.html
+++ b/contact-1/ola/services/business-collaboration/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Business collaboration moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Business collaboration moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/#contact" />
-    <meta http-equiv="refresh" content="0; url=/#contact" />
-    <script>window.location.replace("/#contact");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/#contact" />
+    <script>window.location.replace("https://jadewavesenterprise.com/#contact");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Business collaboration moved to <a href="/#contact">https://jadewavesenterprise.com/#contact</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Business collaboration moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/#contact">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/contact-1/ola/services/product-inquiry-call/index.html
+++ b/contact-1/ola/services/product-inquiry-call/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Product inquiry moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Product inquiry moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/#contact" />
-    <meta http-equiv="refresh" content="0; url=/#contact" />
-    <script>window.location.replace("/#contact");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/#contact" />
+    <script>window.location.replace("https://jadewavesenterprise.com/#contact");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Product inquiry moved to <a href="/#contact">https://jadewavesenterprise.com/#contact</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Product inquiry moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/#contact">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/contact-1/ola/services/request-a-free-sample/index.html
+++ b/contact-1/ola/services/request-a-free-sample/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Sample request moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Sample request moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/#contact" />
-    <meta http-equiv="refresh" content="0; url=/#contact" />
-    <script>window.location.replace("/#contact");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/#contact" />
+    <script>window.location.replace("https://jadewavesenterprise.com/#contact");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Sample request moved to <a href="/#contact">https://jadewavesenterprise.com/#contact</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Sample request moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/#contact">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/copper-slag/index.html
+++ b/copper-slag/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Copper Slag moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Copper slag moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
-    <meta http-equiv="refresh" content="0; url=/products/copper-slag/" />
-    <script>window.location.replace("/products/copper-slag/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Copper Slag moved to <a href="/products/copper-slag/">https://jadewavesenterprise.com/products/copper-slag/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Copper slag moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/copper-slag/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/dolomite/index.html
+++ b/dolomite/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Dolomite page moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Dolomite moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
-    <meta http-equiv="refresh" content="0; url=/products/" />
-    <script>window.location.replace("/products/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Dolomite page moved to <a href="/products/">https://jadewavesenterprise.com/products/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Dolomite moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/earthing-bentonite/index.html
+++ b/earthing-bentonite/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Earthing bentonite page moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Earthing bentonite moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
-    <meta http-equiv="refresh" content="0; url=/products/bentonite/" />
-    <script>window.location.replace("/products/bentonite/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Earthing bentonite page moved to <a href="/products/bentonite/">https://jadewavesenterprise.com/products/bentonite/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Earthing bentonite moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/bentonite/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/faq/index.html
+++ b/faq/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>FAQ moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>FAQ moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
-    <meta http-equiv="refresh" content="0; url=/products/" />
-    <script>window.location.replace("/products/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>FAQ moved to <a href="/products/">https://jadewavesenterprise.com/products/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>FAQ moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/feldspar/index.html
+++ b/feldspar/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Feldspar moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Feldspar moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
-    <meta http-equiv="refresh" content="0; url=/products/feldspar/" />
-    <script>window.location.replace("/products/feldspar/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Feldspar moved to <a href="/products/feldspar/">https://jadewavesenterprise.com/products/feldspar/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Feldspar moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/feldspar/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/fertilizer-bentonite/index.html
+++ b/fertilizer-bentonite/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Fertilizer bentonite page moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Fertilizer bentonite moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
-    <meta http-equiv="refresh" content="0; url=/products/bentonite/" />
-    <script>window.location.replace("/products/bentonite/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Fertilizer bentonite page moved to <a href="/products/bentonite/">https://jadewavesenterprise.com/products/bentonite/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Fertilizer bentonite moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/bentonite/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/fly-ash/index.html
+++ b/fly-ash/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Fly Ash moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Fly ash moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
-    <meta http-equiv="refresh" content="0; url=/products/fly-ash/" />
-    <script>window.location.replace("/products/fly-ash/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Fly Ash moved to <a href="/products/fly-ash/">https://jadewavesenterprise.com/products/fly-ash/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Fly ash moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/fly-ash/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/foundry-bentonite/index.html
+++ b/foundry-bentonite/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Foundry bentonite page moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Foundry bentonite moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
-    <meta http-equiv="refresh" content="0; url=/products/bentonite/" />
-    <script>window.location.replace("/products/bentonite/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Foundry bentonite page moved to <a href="/products/bentonite/">https://jadewavesenterprise.com/products/bentonite/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Foundry bentonite moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/bentonite/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/generate_site.py
+++ b/generate_site.py
@@ -572,19 +572,9 @@ for product in PRODUCTS:
         product["packing"] = packing
 
 PRODUCTS_BY_SLUG = {product["slug"]: product for product in PRODUCTS}
-
-ACTIVE_PRODUCT_SLUGS = ["silica-sand", "quartz-sand-for-ceramics", "feldspar"]
-REDIRECT_PRODUCT_TARGETS = {
-    "bentonite": "/products/",
-    "copper-slag": "/products/",
-    "fly-ash": "/products/",
-    "kaolin--china-clay": "/products/",
-    "salt": "/products/",
-    "silica-flour": "/products/silica-sand/",
-    "talc": "/products/",
-}
-ACTIVE_PRODUCTS = [PRODUCTS_BY_SLUG[slug] for slug in ACTIVE_PRODUCT_SLUGS]
-ACTIVE_PRODUCT_SLUG_SET = set(ACTIVE_PRODUCT_SLUGS)
+PUBLISHED_PRODUCTS = PRODUCTS
+PUBLISHED_PRODUCT_SLUGS = [product["slug"] for product in PUBLISHED_PRODUCTS]
+PUBLISHED_PRODUCT_SLUG_SET = set(PUBLISHED_PRODUCT_SLUGS)
 
 PRODUCT_FAMILIES = [
     {
@@ -592,7 +582,7 @@ PRODUCT_FAMILIES = [
         "name": "Silica, Quartz & Feldspar",
         "copy": "Purity-led grades for glass, ceramics, filtration, and engineered stone.",
         "best_for": ["Glass", "Ceramics", "Filtration", "Engineered Stone"],
-        "products": ACTIVE_PRODUCT_SLUGS,
+        "products": PUBLISHED_PRODUCT_SLUGS,
     },
 ]
 
@@ -1324,25 +1314,82 @@ BLOGS = [
     },
 ]
 
-CURRENT_BLOG_SLUGS = [
-    "quartz-sand-supplier-india-vietnam-buyers-guide",
-    "potassium-vs-sodium-feldspar-import-buyer-guide",
-    "silica-sand-import-checklist-glass-foundry-filtration",
-    "potassium-feldspar-supplier-for-ceramic-tiles",
-    "quartz-powder-supplier-for-engineered-stone",
-    "silica-sand-exporter-from-india",
-    "how-to-check-tds-and-sample-coa-before-mineral-import",
-]
+PUBLISHED_BLOGS = BLOGS
+PUBLISHED_BLOG_SLUGS = [post["slug"] for post in PUBLISHED_BLOGS]
 
-REDIRECT_BLOG_TARGETS = {
-    "bentonite-grade-selection-guide-for-importers": "/blog/",
-    "bentonite-supplier-india": "/blog/",
-    "copper-slag-supplier-for-shipyard-blasting": "/blog/",
-    "fly-ash-exporter-from-india-bulk-shipment": "/blog/",
-    "industrial-salt-exporter": "/blog/",
-    "industrial-salt-import-guide-gulf-buyers": "/blog/",
-    "kaolin-supplier-for-paint-industry": "/blog/",
-}
+LEGACY_ALIAS_REDIRECTS = [
+    ("about-us", "About us moved", "/industrial-minerals-exporter-india/"),
+    ("activated-bleaching-earth", "Activated bleaching earth moved", "/products/"),
+    ("animal-feed-bentonite", "Animal feed bentonite moved", "/products/bentonite/"),
+    ("bentonite", "Bentonite moved", "/products/bentonite/"),
+    ("bentonite-supplier-india", "Bentonite supplier article moved", "/blog/bentonite-supplier-india/"),
+    ("blogs", "Blog index moved", "/blog/"),
+    ("blogs/f/activated-bleaching-earth", "Activated bleaching earth article moved", "/products/"),
+    ("blogs/f/bentonite-clay-and-its-applications", "Bentonite applications article moved", "/products/bentonite/"),
+    ("blogs/f/bentonite-suppliers-in-malaysia", "Bentonite Malaysia article moved", "/products/bentonite/"),
+    ("blogs/f/bentonite-suppliers-in-saudi-arabia", "Bentonite Saudi Arabia article moved", "/products/bentonite/"),
+    ("blogs/f/bentonite-suppliers-in-vietnam", "Bentonite Vietnam article moved", "/products/bentonite/"),
+    ("blogs/f/copper-slag-for-sandblasting", "Copper slag sandblasting article moved", "/blog/copper-slag-supplier-for-shipyard-blasting/"),
+    ("blogs/f/copper-slag-suppliers-in-india", "Copper slag supplier article moved", "/products/copper-slag/"),
+    ("blogs/f/drilling-bentonite", "Drilling bentonite article moved", "/products/bentonite/"),
+    ("blogs/f/fly-ash-suppliers-in-india", "Fly ash supplier article moved", "/blog/fly-ash-exporter-from-india-bulk-shipment/"),
+    ("blogs/f/innovations-in-recycling-fly-ash", "Fly ash recycling article moved", "/blog/fly-ash-exporter-from-india-bulk-shipment/"),
+    ("blogs/f/kaolin-china-clay-suppliers-in-india", "Kaolin article moved", "/products/kaolin--china-clay/"),
+    ("blogs/f/paint-bentonite", "Paint bentonite article moved", "/products/bentonite/"),
+    ("blogs/f/potash-feldspar-feldspar-suppliers-india", "Potash feldspar article moved", "/blog/potassium-feldspar-supplier-for-ceramic-tiles/"),
+    ("blogs/f/quartz-supplier-in-vietnam---quartz-india", "Quartz Vietnam article moved", "/blog/quartz-sand-supplier-india-vietnam-buyers-guide/"),
+    ("blogs/f/rubber-granules-maldives-rubber-granules-supplier-in-maldives", "Rubber granules article moved", "/products/"),
+    ("blogs/f/salt-suppliers-in-mauritius-jade-waves-enterprise", "Salt Mauritius article moved", "/blog/industrial-salt-exporter/"),
+    ("blogs/f/salt-suppliers-in-seychelles-jade-waves-enteprise", "Salt Seychelles article moved", "/blog/industrial-salt-exporter/"),
+    ("blogs/f/salt-the-essential-mineral", "Salt article moved", "/products/salt/"),
+    ("blogs/f/silica-sand-for-artificial-football-turf", "Silica turf article moved", "/products/silica-sand/"),
+    ("blogs/f/silica-sand-maldives", "Silica sand Maldives article moved", "/products/silica-sand/"),
+    ("blogs/f/silica-sand-suppliers-in-kenya", "Silica Kenya article moved", "/blog/silica-sand-exporter-from-india/"),
+    ("blogs/f/silica-sand-suppliers-in-mauritius-jade-waves-enterprise", "Silica Mauritius article moved", "/products/silica-sand/"),
+    ("blogs/f/the-future-of-fly-ash-utilization-in-green-building-practices", "Fly ash green building article moved", "/blog/fly-ash-exporter-from-india-bulk-shipment/"),
+    ("blogs/f/the-role-of-fly-ash-in-cement-manufacturing", "Fly ash cement article moved", "/blog/fly-ash-exporter-from-india-bulk-shipment/"),
+    ("blogs/f/top-silica-sand-suppliers-in-india-jade-waves-enterprise", "Silica suppliers article moved", "/blog/silica-sand-exporter-from-india/"),
+    ("cat-litter-bentonite", "Cat litter bentonite moved", "/products/bentonite/"),
+    ("ceramics-bentonite", "Ceramics bentonite moved", "/products/bentonite/"),
+    ("company-profile", "Company profile moved", "/industrial-minerals-exporter-india/"),
+    ("contact-1", "Contact moved", "/#contact"),
+    ("contact-1/ola/services/business-collaboration", "Business collaboration moved", "/#contact"),
+    ("contact-1/ola/services/product-inquiry-call", "Product inquiry moved", "/#contact"),
+    ("contact-1/ola/services/request-a-free-sample", "Sample request moved", "/#contact"),
+    ("copper-slag", "Copper slag moved", "/products/copper-slag/"),
+    ("dolomite", "Dolomite moved", "/products/"),
+    ("earthing-bentonite", "Earthing bentonite moved", "/products/bentonite/"),
+    ("faq", "FAQ moved", "/products/"),
+    ("feldspar", "Feldspar moved", "/products/feldspar/"),
+    ("fertilizer-bentonite", "Fertilizer bentonite moved", "/products/bentonite/"),
+    ("fly-ash", "Fly ash moved", "/products/fly-ash/"),
+    ("foundry-bentonite", "Foundry bentonite moved", "/products/bentonite/"),
+    ("hdd-bentonite", "HDD bentonite moved", "/products/bentonite/"),
+    ("hear-from-our-ceo", "CEO page moved", "/hear-from-ceo/"),
+    ("home", "Home moved", "/"),
+    ("infrastructure", "Infrastructure moved", "/operations/"),
+    ("kaolin--china-clay", "Kaolin moved", "/products/kaolin--china-clay/"),
+    ("limestone-/-dolomite", "Dolomite moved", "/products/"),
+    ("m/create-account", "Account creation moved", "/#contact"),
+    ("m/login", "Login moved", "/#contact"),
+    ("m/reset", "Reset moved", "/#contact"),
+    ("oil-drilling-bentonite", "Oil drilling bentonite moved", "/products/bentonite/"),
+    ("piling-bentonite", "Piling bentonite moved", "/products/bentonite/"),
+    ("pond-sealing-bentonite", "Pond sealing bentonite moved", "/products/bentonite/"),
+    ("potash-&-soda-feldspar", "Feldspar moved", "/products/feldspar/"),
+    ("quartz", "Quartz moved", "/products/quartz-sand-for-ceramics/"),
+    ("quartz-sand-for-ceramics", "Quartz sand moved", "/products/quartz-sand-for-ceramics/"),
+    ("refractory-bentonite", "Refractory bentonite moved", "/products/bentonite/"),
+    ("rubber-granules", "Rubber granules moved", "/products/"),
+    ("salt", "Salt moved", "/products/salt/"),
+    ("silica-flour", "Silica flour moved", "/products/silica-flour/"),
+    ("silica-sand", "Silica sand moved", "/products/silica-sand/"),
+    ("silica-sand-india", "Silica sand moved", "/products/silica-sand/"),
+    ("silicasand-supplier-india", "Silica sand moved", "/products/silica-sand/"),
+    ("talc", "Talc moved", "/products/talc/"),
+    ("talc-/-soapstone", "Talc moved", "/products/talc/"),
+    ("terms-and-conditions", "Terms moved", "/terms-disclaimer/"),
+]
 
 
 def write(path: Path, content: str) -> None:
@@ -1491,7 +1538,7 @@ def render_redirect_page(title: str, description: str, from_path: str, to_path: 
             <meta name="viewport" content="width=device-width, initial-scale=1.0" />
             <title>{escape(title)}</title>
             <meta name="description" content="{escape(description)}" />
-            <meta name="robots" content="noindex,follow" />
+            <meta name="robots" content="index,follow" />
             <link rel="canonical" href="{escape(target_url)}" />
             <meta http-equiv="refresh" content="0; url={escape(target_url)}" />
             <script>window.location.replace({json.dumps(target_url)});</script>
@@ -1589,7 +1636,7 @@ def form_block(product_name: str = "") -> str:
 
 def product_select() -> str:
     options = ['<option value="">Select product</option>']
-    for product in ACTIVE_PRODUCTS:
+    for product in PUBLISHED_PRODUCTS:
         options.append(f'<option value="{escape(product["name"])}">{escape(product["name"])}</option>')
     return "<select name=\"product\">" + "".join(options) + "</select>"
 
@@ -1597,7 +1644,7 @@ def product_select() -> str:
 def related_links(slugs: list[str]) -> str:
     links = []
     for slug in slugs:
-        if slug not in ACTIVE_PRODUCT_SLUG_SET:
+        if slug not in PUBLISHED_PRODUCT_SLUG_SET:
             continue
         product = PRODUCTS_BY_SLUG[slug]
         links.append(
@@ -1740,8 +1787,7 @@ def render_homepage() -> str:
     )
     guide_links_once = "".join(
         f'<a class="buyer-guide-pill" href="/blog/">{escape(post.get("marquee_title", post["title"]))}</a>'
-        for post in BLOGS
-        if post["slug"] in CURRENT_BLOG_SLUGS
+        for post in PUBLISHED_BLOGS
     )
     guide_links_markup = guide_links_once + guide_links_once
     home_body = dedent(
@@ -1986,7 +2032,7 @@ def render_homepage() -> str:
                     "url": f"{BASE_URL}/products/{product['slug']}/",
                     "name": product["name"],
                 }
-                for index, product in enumerate(ACTIVE_PRODUCTS)
+                for index, product in enumerate(PUBLISHED_PRODUCTS)
             ],
         },
     ]
@@ -2001,7 +2047,7 @@ def render_homepage() -> str:
 
 
 def render_blog_index_page() -> str:
-    current_posts = [post for post in BLOGS if post["slug"] in CURRENT_BLOG_SLUGS]
+    current_posts = PUBLISHED_BLOGS
     post_cards = []
     for post in current_posts:
         product = PRODUCTS_BY_SLUG[post["product_slug"]]
@@ -2178,8 +2224,6 @@ def render_blog_post_page(post: dict) -> str:
     questions_markup = "".join(f"<li>{escape(question)}</li>" for question in post["questions"])
     related_cards = []
     for related in BLOGS:
-        if related["slug"] not in CURRENT_BLOG_SLUGS:
-            continue
         if related["slug"] == post["slug"]:
             continue
         related_cards.append(
@@ -2440,7 +2484,7 @@ def render_products_index() -> str:
                     "url": f"{BASE_URL}/products/{product['slug']}/",
                     "name": product["name"],
                 }
-                for index, product in enumerate(ACTIVE_PRODUCTS)
+                for index, product in enumerate(PUBLISHED_PRODUCTS)
             ],
         },
     ]
@@ -9136,8 +9180,8 @@ def render_sitemap() -> str:
         "/privacy-policy/",
         "/products/",
         "/terms-disclaimer/",
-        *[f"/blog/{post['slug']}/" for post in BLOGS if post["slug"] in CURRENT_BLOG_SLUGS],
-        *[f"/products/{product['slug']}/" for product in ACTIVE_PRODUCTS],
+        *[f"/blog/{post['slug']}/" for post in PUBLISHED_BLOGS],
+        *[f"/products/{product['slug']}/" for product in PUBLISHED_PRODUCTS],
     ]
     entries = "\n".join(
         f"  <url><loc>{BASE_URL}{path}</loc><lastmod>{TODAY}</lastmod></url>"
@@ -9156,33 +9200,30 @@ def main() -> None:
     write(ROOT / "script.js", SCRIPT)
     write(ROOT / "index.html", render_homepage())
     write(ROOT / "blog" / "index.html", render_blog_index_page())
-    for blog_post in BLOGS:
-      if blog_post["slug"] in CURRENT_BLOG_SLUGS:
-        write(ROOT / "blog" / blog_post["slug"] / "index.html", render_blog_post_page(blog_post))
-    for slug, target in REDIRECT_BLOG_TARGETS.items():
-      write(
-          ROOT / "blog" / slug / "index.html",
-          render_redirect_page(
-              "Blog Redirect | Jade Waves Enterprise",
-              "This article has been consolidated into the current Jade Waves content hub.",
-              f"/blog/{slug}/",
-              target,
-          ),
-      )
+    for blog_post in PUBLISHED_BLOGS:
+      write(ROOT / "blog" / blog_post["slug"] / "index.html", render_blog_post_page(blog_post))
     write(ROOT / "hear-from-ceo" / "index.html", render_ceo_page())
     write(ROOT / "export-markets" / "index.html", render_export_markets_page())
     write(ROOT / "industrial-minerals-exporter-india" / "index.html", render_exporter_profile_page())
     write(ROOT / "products" / "index.html", render_products_index())
-    for product in ACTIVE_PRODUCTS:
+    for product in PUBLISHED_PRODUCTS:
       write(ROOT / "products" / product["slug"] / "index.html", render_product_page(product))
-    for slug, target in REDIRECT_PRODUCT_TARGETS.items():
-      product_name = slug.replace("-", " ").replace("--", " ")
       write(
-          ROOT / "products" / slug / "index.html",
+          ROOT / product["slug"] / "index.html",
           render_redirect_page(
-              f"{product_name.title()} Redirect | Jade Waves Enterprise",
-              "This product page has been consolidated into the current Jade Waves portfolio.",
-              f"/products/{slug}/",
+              f"{product['name']} moved",
+              "This legacy product URL now points to the canonical product page.",
+              f"/{product['slug']}/",
+              f"/products/{product['slug']}/",
+          ),
+      )
+    for path, title, target in LEGACY_ALIAS_REDIRECTS:
+      write(
+          ROOT / path / "index.html",
+          render_redirect_page(
+              title,
+              "This legacy URL now points to the current Jade Waves page.",
+              f"/{path.strip('/')}/",
               target,
           ),
       )

--- a/hdd-bentonite/index.html
+++ b/hdd-bentonite/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>HDD bentonite page moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>HDD bentonite moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
-    <meta http-equiv="refresh" content="0; url=/products/bentonite/" />
-    <script>window.location.replace("/products/bentonite/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>HDD bentonite page moved to <a href="/products/bentonite/">https://jadewavesenterprise.com/products/bentonite/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>HDD bentonite moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/bentonite/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/hear-from-our-ceo/index.html
+++ b/hear-from-our-ceo/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>CEO page moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>CEO page moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/hear-from-ceo/" />
-    <meta http-equiv="refresh" content="0; url=/hear-from-ceo/" />
-    <script>window.location.replace("/hear-from-ceo/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/hear-from-ceo/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/hear-from-ceo/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>CEO page moved to <a href="/hear-from-ceo/">https://jadewavesenterprise.com/hear-from-ceo/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>CEO page moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/hear-from-ceo/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/home/index.html
+++ b/home/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Home moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Home moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/" />
-    <meta http-equiv="refresh" content="0; url=/" />
-    <script>window.location.replace("/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Home moved to <a href="/">https://jadewavesenterprise.com/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Home moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
   gtag('js', new Date());
   gtag('config', 'G-9BRL4JKNN6');
 </script>
-                <script type="application/ld+json">[{"@context": "https://schema.org", "@type": "Organization", "name": "Jade Waves Enterprise", "url": "https://jadewavesenterprise.com", "email": "deep@jadewavesenterprise.com", "telephone": "+91-999-883-5503", "addressCountry": "IN"}, {"@context": "https://schema.org", "@type": "ItemList", "name": "Jade Waves Enterprise Product Portfolio", "itemListElement": [{"@type": "ListItem", "position": 1, "url": "https://jadewavesenterprise.com/products/silica-sand/", "name": "Silica Sand"}, {"@type": "ListItem", "position": 2, "url": "https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/", "name": "Quartz Sand"}, {"@type": "ListItem", "position": 3, "url": "https://jadewavesenterprise.com/products/feldspar/", "name": "Feldspar"}]}]</script>
+                <script type="application/ld+json">[{"@context": "https://schema.org", "@type": "Organization", "name": "Jade Waves Enterprise", "url": "https://jadewavesenterprise.com", "email": "deep@jadewavesenterprise.com", "telephone": "+91-999-883-5503", "addressCountry": "IN"}, {"@context": "https://schema.org", "@type": "ItemList", "name": "Jade Waves Enterprise Product Portfolio", "itemListElement": [{"@type": "ListItem", "position": 1, "url": "https://jadewavesenterprise.com/products/silica-sand/", "name": "Silica Sand"}, {"@type": "ListItem", "position": 2, "url": "https://jadewavesenterprise.com/products/silica-flour/", "name": "Silica Flour"}, {"@type": "ListItem", "position": 3, "url": "https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/", "name": "Quartz Sand"}, {"@type": "ListItem", "position": 4, "url": "https://jadewavesenterprise.com/products/bentonite/", "name": "Bentonite"}, {"@type": "ListItem", "position": 5, "url": "https://jadewavesenterprise.com/products/kaolin--china-clay/", "name": "Kaolin (China Clay)"}, {"@type": "ListItem", "position": 6, "url": "https://jadewavesenterprise.com/products/talc/", "name": "Talc"}, {"@type": "ListItem", "position": 7, "url": "https://jadewavesenterprise.com/products/feldspar/", "name": "Feldspar"}, {"@type": "ListItem", "position": 8, "url": "https://jadewavesenterprise.com/products/salt/", "name": "Salt"}, {"@type": "ListItem", "position": 9, "url": "https://jadewavesenterprise.com/products/fly-ash/", "name": "Fly Ash"}, {"@type": "ListItem", "position": 10, "url": "https://jadewavesenterprise.com/products/copper-slag/", "name": "Copper Slag"}]}]</script>
                 <script defer src="/script.js"></script>
               </head>
               <body class="antialiased page-home">
@@ -177,7 +177,7 @@
                 <article class="home-family-row" data-reveal>
       <span class="home-family-row__index">01</span>
       <div class="home-family-row__main">
-        <p class="home-family-row__count">3 products</p>
+        <p class="home-family-row__count">10 products</p>
         <h3><a class="home-family-row__family-link" href="/products/#silica-quartz-feldspar">Silica, Quartz &amp; Feldspar</a></h3>
         <p>Purity-led grades for glass, ceramics, filtration, and engineered stone.</p>
         <div class="home-family-row__products">
@@ -186,13 +186,48 @@
   <em aria-hidden="true">→</em>
 </a>
 
+<a class="home-family-row__product" href="/products/silica-flour/">
+  <span>Silica Flour</span>
+  <em aria-hidden="true">→</em>
+</a>
+
 <a class="home-family-row__product" href="/products/quartz-sand-for-ceramics/">
   <span>Quartz Sand</span>
   <em aria-hidden="true">→</em>
 </a>
 
+<a class="home-family-row__product" href="/products/bentonite/">
+  <span>Bentonite</span>
+  <em aria-hidden="true">→</em>
+</a>
+
+<a class="home-family-row__product" href="/products/kaolin--china-clay/">
+  <span>Kaolin (China Clay)</span>
+  <em aria-hidden="true">→</em>
+</a>
+
+<a class="home-family-row__product" href="/products/talc/">
+  <span>Talc</span>
+  <em aria-hidden="true">→</em>
+</a>
+
 <a class="home-family-row__product" href="/products/feldspar/">
   <span>Feldspar</span>
+  <em aria-hidden="true">→</em>
+</a>
+
+<a class="home-family-row__product" href="/products/salt/">
+  <span>Salt</span>
+  <em aria-hidden="true">→</em>
+</a>
+
+<a class="home-family-row__product" href="/products/fly-ash/">
+  <span>Fly Ash</span>
+  <em aria-hidden="true">→</em>
+</a>
+
+<a class="home-family-row__product" href="/products/copper-slag/">
+  <span>Copper Slag</span>
   <em aria-hidden="true">→</em>
 </a>
 </div>
@@ -387,7 +422,7 @@
       </label>
       <label>
         <span>Product</span>
-        <select name="product"><option value="">Select product</option><option value="Silica Sand">Silica Sand</option><option value="Quartz Sand">Quartz Sand</option><option value="Feldspar">Feldspar</option></select>
+        <select name="product"><option value="">Select product</option><option value="Silica Sand">Silica Sand</option><option value="Silica Flour">Silica Flour</option><option value="Quartz Sand">Quartz Sand</option><option value="Bentonite">Bentonite</option><option value="Kaolin (China Clay)">Kaolin (China Clay)</option><option value="Talc">Talc</option><option value="Feldspar">Feldspar</option><option value="Salt">Salt</option><option value="Fly Ash">Fly Ash</option><option value="Copper Slag">Copper Slag</option></select>
       </label>
       <label>
         <span>Name</span>

--- a/infrastructure/index.html
+++ b/infrastructure/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Infrastructure moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Infrastructure moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
-    <meta http-equiv="refresh" content="0; url=/operations/" />
-    <script>window.location.replace("/operations/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Infrastructure moved to <a href="/operations/">https://jadewavesenterprise.com/operations/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Infrastructure moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/operations/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/kaolin--china-clay/index.html
+++ b/kaolin--china-clay/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Kaolin (China Clay) moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Kaolin moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
-    <meta http-equiv="refresh" content="0; url=/products/kaolin--china-clay/" />
-    <script>window.location.replace("/products/kaolin--china-clay/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Kaolin (China Clay) moved to <a href="/products/kaolin--china-clay/">https://jadewavesenterprise.com/products/kaolin--china-clay/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Kaolin moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/kaolin--china-clay/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/limestone-/-dolomite/index.html
+++ b/limestone-/-dolomite/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Dolomite page moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Dolomite moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
-    <meta http-equiv="refresh" content="0; url=/products/" />
-    <script>window.location.replace("/products/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Dolomite page moved to <a href="/products/">https://jadewavesenterprise.com/products/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Dolomite moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/m/create-account/index.html
+++ b/m/create-account/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Account creation moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
-    <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
-    <meta http-equiv="refresh" content="0; url=/products/bentonite/" />
-    <script>window.location.replace("/products/bentonite/");</script>
+    <title>Account creation moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
+    <link rel="canonical" href="https://jadewavesenterprise.com/#contact" />
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/#contact" />
+    <script>window.location.replace("https://jadewavesenterprise.com/#contact");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Account creation moved to <a href="/products/bentonite/">https://jadewavesenterprise.com/products/bentonite/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Account creation moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/#contact">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/m/login/index.html
+++ b/m/login/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Login moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
-    <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
-    <meta http-equiv="refresh" content="0; url=/products/bentonite/" />
-    <script>window.location.replace("/products/bentonite/");</script>
+    <title>Login moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
+    <link rel="canonical" href="https://jadewavesenterprise.com/#contact" />
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/#contact" />
+    <script>window.location.replace("https://jadewavesenterprise.com/#contact");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Login moved to <a href="/products/bentonite/">https://jadewavesenterprise.com/products/bentonite/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Login moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/#contact">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/m/reset/index.html
+++ b/m/reset/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Reset moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
-    <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
-    <meta http-equiv="refresh" content="0; url=/products/bentonite/" />
-    <script>window.location.replace("/products/bentonite/");</script>
+    <title>Reset moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
+    <link rel="canonical" href="https://jadewavesenterprise.com/#contact" />
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/#contact" />
+    <script>window.location.replace("https://jadewavesenterprise.com/#contact");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Reset moved to <a href="/products/bentonite/">https://jadewavesenterprise.com/products/bentonite/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Reset moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/#contact">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/oil-drilling-bentonite/index.html
+++ b/oil-drilling-bentonite/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Drilling bentonite page moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Oil drilling bentonite moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
-    <meta http-equiv="refresh" content="0; url=/products/bentonite/" />
-    <script>window.location.replace("/products/bentonite/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Drilling bentonite page moved to <a href="/products/bentonite/">https://jadewavesenterprise.com/products/bentonite/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Oil drilling bentonite moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/bentonite/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/piling-bentonite/index.html
+++ b/piling-bentonite/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Piling bentonite page moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Piling bentonite moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
-    <meta http-equiv="refresh" content="0; url=/products/bentonite/" />
-    <script>window.location.replace("/products/bentonite/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Piling bentonite page moved to <a href="/products/bentonite/">https://jadewavesenterprise.com/products/bentonite/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Piling bentonite moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/bentonite/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/pond-sealing-bentonite/index.html
+++ b/pond-sealing-bentonite/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Pond sealing bentonite page moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Pond sealing bentonite moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
-    <meta http-equiv="refresh" content="0; url=/products/bentonite/" />
-    <script>window.location.replace("/products/bentonite/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Pond sealing bentonite page moved to <a href="/products/bentonite/">https://jadewavesenterprise.com/products/bentonite/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Pond sealing bentonite moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/bentonite/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/potash-&-soda-feldspar/index.html
+++ b/potash-&-soda-feldspar/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Feldspar page moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Feldspar moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
-    <meta http-equiv="refresh" content="0; url=/products/feldspar/" />
-    <script>window.location.replace("/products/feldspar/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Feldspar page moved to <a href="/products/feldspar/">https://jadewavesenterprise.com/products/feldspar/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Feldspar moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/feldspar/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/products/bentonite/index.html
+++ b/products/bentonite/index.html
@@ -1,22 +1,353 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Bentonite Redirect | Jade Waves Enterprise</title>
-    <meta name="description" content="This product page has been consolidated into the current Jade Waves portfolio." />
-    <meta name="robots" content="noindex,follow" />
-    <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
-    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
-    <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>
-    <link rel="stylesheet" href="/styles.css" />
-  </head>
-  <body class="antialiased page-redirect">
-    <main class="shell" style="padding: 6rem 1.5rem;">
-      <p class="section-label">Redirecting</p>
-      <h1>Bentonite Redirect | Jade Waves Enterprise</h1>
-      <p>This product page has been consolidated into the current Jade Waves portfolio.</p>
-      <p><a href="/products/">Continue to the current page</a></p>
-    </main>
-  </body>
-</html>
+            <html lang="en">
+              <head>
+                <meta charset="UTF-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                <title>Bentonite Supplier &amp; Exporter from India | Jade Waves Enterprise</title>
+                <meta name="description" content="Bulk bentonite supplier and exporter from India for drilling, foundry, sealing, and absorbent buyers in Vietnam, UAE, Oman, Qatar, Bahrain, Saudi Arabia, and Malaysia." />
+                <meta name="robots" content="index,follow" />
+                <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
+                <meta property="og:title" content="Bentonite Supplier &amp; Exporter from India | Jade Waves Enterprise" />
+                <meta property="og:description" content="Bulk bentonite supplier and exporter from India for drilling, foundry, sealing, and absorbent buyers in Vietnam, UAE, Oman, Qatar, Bahrain, Saudi Arabia, and Malaysia." />
+                <meta property="og:type" content="website" />
+                <meta property="og:url" content="https://jadewavesenterprise.com/products/bentonite/" />
+                <meta property="og:site_name" content="Jade Waves Enterprise" />
+                <meta property="og:image" content="https://jadewavesenterprise.com/assets/jade-waves-logo-transparent.png" />
+                <link rel="preconnect" href="https://fonts.googleapis.com" />
+                <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+                <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+                <link rel="stylesheet" href="/styles.css" />
+                <script async src="https://www.googletagmanager.com/gtag/js?id=G-9BRL4JKNN6"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-9BRL4JKNN6');
+</script>
+                <script type="application/ld+json">[{"@context": "https://schema.org", "@type": "Product", "name": "Bentonite", "description": "Bulk bentonite supplier and exporter from India for drilling, foundry, sealing, and absorbent buyers in Vietnam, UAE, Oman, Qatar, Bahrain, Saudi Arabia, and Malaysia.", "category": "Industrial Mineral", "brand": {"@type": "Brand", "name": "Jade Waves Enterprise"}, "manufacturer": {"@type": "Organization", "name": "Jade Waves Enterprise"}, "url": "https://jadewavesenterprise.com/products/bentonite/"}, {"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "Home", "item": "https://jadewavesenterprise.com"}, {"@type": "ListItem", "position": 2, "name": "Products", "item": "https://jadewavesenterprise.com/products/"}, {"@type": "ListItem", "position": 3, "name": "Bentonite", "item": "https://jadewavesenterprise.com/products/bentonite/"}]}, {"@context": "https://schema.org", "@type": "FAQPage", "mainEntity": [{"@type": "Question", "name": "What applications is Bentonite supplied for?", "acceptedAnswer": {"@type": "Answer", "text": "Bentonite is supplied for drilling fluids for oil, gas, and HDD, foundry and casting systems, and construction, sealing, and waterproofing work, with grade and sizing aligned to the end use."}}, {"@type": "Question", "name": "What should be confirmed before ordering Bentonite?", "acceptedAnswer": {"@type": "Answer", "text": "Confirm application, sodium or calcium grade, pH, liquid limit, and viscosity target, and moisture and filtrate loss so pricing, sampling, and dispatch can be aligned correctly."}}, {"@type": "Question", "name": "How is Bentonite handled for export?", "acceptedAnswer": {"@type": "Answer", "text": "Supply formats include 50 Kg/Jumbo Bags. Jade Waves aligns samples, export documents, and shipment planning from India to suit the destination and order size."}}]}]</script>
+                <script defer src="/script.js"></script>
+              </head>
+              <body class="antialiased page-product">
+                <header class="site-header" data-header>
+  <div class="site-header__inner">
+    <a class="brand-mark" href="/" aria-label="Jade Waves Enterprise home">
+      <img src="/assets/jade-waves-logo-transparent.png" alt="Jade Waves Enterprise logo" />
+    </a>
+    <nav class="desktop-nav" aria-label="Primary">
+      <a href="/#about">About</a>
+      <a href="/products/">Products</a>
+      <a href="/operations/">Operations</a>
+      <a href="/blog/">Blog</a>
+      <a href="/export-markets/">Markets</a>
+      <a href="/#contact">Contact</a>
+    </nav>
+    <div class="header-actions">
+      <a class="button button--dark button--compact" href="/#contact" data-set-request="Quote">Request Quote</a>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu" data-menu-toggle>
+        Menu
+      </button>
+    </div>
+  </div>
+  <div class="mobile-menu" id="mobile-menu" data-mobile-menu hidden>
+    <a href="/#about">About</a>
+    <a href="/products/">Products</a>
+    <a href="/operations/">Operations</a>
+    <a href="/blog/">Blog</a>
+    <a href="/export-markets/">Markets</a>
+    <a href="/#contact">Contact</a>
+  </div>
+</header>
+        <main>
+          <section class="hero hero--product theme-clay">
+            <div class="hero__strata" aria-hidden="true">
+              <span class="strata strata--a"></span>
+              <span class="strata strata--b"></span>
+              <span class="strata strata--c"></span>
+              <span class="route-line route-line--hero"></span>
+            </div>
+            <div class="shell hero__inner hero__inner--product product-hero">
+              <div class="hero-copy hero-copy--product" data-reveal>
+                <div class="breadcrumb">
+                  <a href="/">Home</a>
+                  <span>/</span>
+                  <a href="/products/">Products</a>
+                  <span>/</span>
+                  <strong>Bentonite</strong>
+                </div>
+                <p class="hero-label">Drilling / Foundry / Civil / Absorbent Grades</p>
+                <h1>Bentonite</h1>
+                <p class="hero-text">Bentonite for drilling, foundry, sealing, absorbent, and bleaching grades where swelling, viscosity, and moisture control need to stay dependable for bulk export buyers.</p>
+                <div class="hero-actions">
+                  <a class="button button--light" href="#contact" data-set-request="Quote">Request Quote</a>
+                  <a class="button button--ghost" href="#contact" data-set-request="Sample">Request Sample</a>
+                </div>
+              </div>
+              <aside class="product-poster" data-reveal data-parallax="0.12">
+                <div class="product-poster__surface">
+                  <span class="ore-pillar ore-pillar--a"></span>
+                  <span class="ore-pillar ore-pillar--b"></span>
+                  <span class="ore-pillar ore-pillar--c"></span>
+                  <p class="product-poster__eyebrow">At a glance</p>
+                  <strong class="product-poster__title">Bentonite</strong>
+                  <p class="product-poster__copy">Bentonite supplier for drilling, foundry, sealing, absorbent, and bleaching use.</p>
+                  <div class="product-poster__metrics">
+                    <article class="product-poster__metric">
+  <span>Primary Use</span>
+  <strong>Drilling fluids for oil, gas, and HDD</strong>
+</article><article class="product-poster__metric">
+  <span>Typical Spec</span>
+  <strong>pH 9-11 / Liquid limit 450 min</strong>
+</article><article class="product-poster__metric">
+  <span>Packing</span>
+  <strong>50 Kg/Jumbo Bags</strong>
+</article><article class="product-poster__metric">
+  <span>Shipment</span>
+  <strong>FCL</strong>
+</article>
+                  </div>
+                  <div class="product-poster__caption">
+                    <p>Sample, documents, and dispatch stay on one clear track.</p>
+                  </div>
+                  <span class="route-line route-line--snapshot"></span>
+                </div>
+              </aside>
+            </div>
+          </section>
+
+          <section class="section-block">
+
+            <div class="shell product-ledger">
+              <article class="product-sheet product-sheet--wide" data-reveal>
+                <p class="section-label">Applications</p>
+                <h2>Where it fits best.</h2>
+                <p class="product-sheet__intro">Common end uses where grade, form, and delivery have to line up.</p>
+                <div class="product-line-list"><article class="product-line">
+  <span>01</span>
+  <div>
+    <strong>Drilling fluids for oil, gas, and HDD</strong>
+  </div>
+</article><article class="product-line">
+  <span>02</span>
+  <div>
+    <strong>Foundry and casting systems</strong>
+  </div>
+</article><article class="product-line">
+  <span>03</span>
+  <div>
+    <strong>Construction, sealing, and waterproofing work</strong>
+  </div>
+</article><article class="product-line">
+  <span>04</span>
+  <div>
+    <strong>Cat litter and absorbent applications</strong>
+  </div>
+</article><article class="product-line">
+  <span>05</span>
+  <div>
+    <strong>Activated bleaching earth and filtration use</strong>
+  </div>
+</article></div>
+              </article>
+              <article class="product-sheet" data-reveal>
+                <p class="section-label">Supply Snapshot</p>
+                <h2>Supply, packing, and shipment.</h2>
+                <div class="product-info-list"><article class="product-info-row">
+  <span>Forms</span>
+  <strong>Sodium bentonite, Calcium bentonite, and Application-specific bentonite grades</strong>
+</article><article class="product-info-row">
+  <span>Packing</span>
+  <strong>50 Kg/Jumbo Bags</strong>
+</article><article class="product-info-row">
+  <span>Shipment</span>
+  <strong>FCL</strong>
+</article></div>
+                <div class="form-cloud product-form-cloud"><span class="form-pill">Sodium bentonite</span><span class="form-pill">Calcium bentonite</span><span class="form-pill">Application-specific bentonite grades</span><span class="form-pill">Activated Bleaching Earth</span></div>
+              </article>
+
+            </div>
+          </section>
+
+          <section class="section-block section-block--contrast">
+            <div class="shell product-ledger">
+              <article class="product-sheet product-sheet--wide" data-reveal>
+                <p class="section-label">Specification Focus</p>
+                <h2>What should be confirmed.</h2>
+                <div class="product-line-list product-line-list--booking"><article class="product-line product-line--booking">
+  <span>01</span>
+  <div>
+    <strong>Application</strong>
+  </div>
+</article><article class="product-line product-line--booking">
+  <span>02</span>
+  <div>
+    <strong>Sodium or calcium grade</strong>
+  </div>
+</article><article class="product-line product-line--booking">
+  <span>03</span>
+  <div>
+    <strong>pH, liquid limit, and viscosity target</strong>
+  </div>
+</article><article class="product-line product-line--booking">
+  <span>04</span>
+  <div>
+    <strong>Moisture and filtrate loss</strong>
+  </div>
+</article><article class="product-line product-line--booking">
+  <span>05</span>
+  <div>
+    <strong>Packing and order volume</strong>
+  </div>
+</article></div>
+              </article>
+              <article class="product-sheet" data-reveal>
+                <p class="section-label">Commercial Fit</p>
+                <h2>Why buyers choose it.</h2>
+                <p class="product-sheet__body">For operations that need bentonite to perform the same way from batch to batch.</p>
+                <div class="product-tag-cloud"><span>Drilling</span><span>Foundry</span><span>Construction</span><span>Treatment</span></div>
+                <div class="product-note-list"><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>Moisture specified at 14% max</p>
+</article><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>Liquid limit specified at 450 min</p>
+</article><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>Gel index specified at 60 min</p>
+</article><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>Marsh funnel viscosity specified at 50 sec min</p>
+</article></div>
+              </article>
+            </div>
+          </section>
+
+          <section class="section-block">
+            <div class="shell section-shell">
+              <div class="section-intro" data-reveal>
+                <p class="section-label">Also In The Portfolio</p>
+                <h2>More from the range.</h2>
+              </div>
+              <div class="related-links" data-reveal><a href="/products/kaolin--china-clay/">Kaolin (China Clay)</a><a href="/products/talc/">Talc</a><a href="/products/fly-ash/">Fly Ash</a></div>
+            </div>
+          </section>
+
+          <section class="section-block section-block--contrast">
+            <div class="shell section-shell">
+              <div class="section-intro" data-reveal>
+                <p class="section-label">FAQ</p>
+                <h2>Questions that usually come first.</h2>
+                <p>Direct answers before pricing, sampling, and dispatch.</p>
+              </div>
+              <div class="faq-shell"><details class="faq-item" data-reveal>
+  <summary>What applications is Bentonite supplied for?</summary>
+  <p>Bentonite is supplied for drilling fluids for oil, gas, and HDD, foundry and casting systems, and construction, sealing, and waterproofing work, with grade and sizing aligned to the end use.</p>
+</details><details class="faq-item" data-reveal>
+  <summary>What should be confirmed before ordering Bentonite?</summary>
+  <p>Confirm application, sodium or calcium grade, pH, liquid limit, and viscosity target, and moisture and filtrate loss so pricing, sampling, and dispatch can be aligned correctly.</p>
+</details><details class="faq-item" data-reveal>
+  <summary>How is Bentonite handled for export?</summary>
+  <p>Supply formats include 50 Kg/Jumbo Bags. Jade Waves aligns samples, export documents, and shipment planning from India to suit the destination and order size.</p>
+</details></div>
+            </div>
+          </section>
+
+          <section class="section-block section-block--contact">
+            <div class="shell section-shell">
+              <div class="contact-shell" id="contact">
+  <div class="contact-copy" data-reveal>
+    <p class="section-label">Contact</p>
+    <h2>Start the inquiry.</h2>
+    <p>
+      Share the product, end use, destination, and expected volume. We’ll align fit, packing, and shipment terms from there.
+    </p>
+    <div class="contact-details">
+      <a href="mailto:deep@jadewavesenterprise.com">deep@jadewavesenterprise.com</a>
+      <a href="tel:+91-999-883-5503">+91-999-883-5503</a>
+    </div>
+  </div>
+  <form class="inquiry-form" data-inquiry-form data-reveal>
+    <div class="form-grid">
+      <label>
+        <span>Request Type</span>
+        <select name="request_type">
+          <option>Quote</option>
+          <option>Sample</option>
+          <option>General Inquiry</option>
+        </select>
+      </label>
+      <label>
+        <span>Product</span>
+        <input type="text" name="product" value="Bentonite" readonly />
+      </label>
+      <label>
+        <span>Name</span>
+        <input type="text" name="name" placeholder="Your name" required />
+      </label>
+      <label>
+        <span>Company</span>
+        <input type="text" name="company" placeholder="Company name" />
+      </label>
+      <label>
+        <span>Email</span>
+        <input type="email" name="email" placeholder="you@company.com" required />
+      </label>
+      <label>
+        <span>Phone</span>
+        <input type="text" name="phone" placeholder="+91 / country code" />
+      </label>
+      <label>
+        <span>Application</span>
+        <input type="text" name="application" placeholder="End use or industry" />
+      </label>
+      <label>
+        <span>Volume</span>
+        <input type="text" name="volume" placeholder="Trial / monthly volume" />
+      </label>
+      <label>
+        <span>Packing Size</span>
+        <input type="text" name="packing_size" placeholder="50 Kg bags / Jumbo bags / bulk" />
+      </label>
+      <label class="form-grid__wide">
+        <span>Requirement</span>
+        <textarea name="notes" rows="4" placeholder="Share grade, packing, destination, or any spec points that matter."></textarea>
+      </label>
+    </div>
+    <div class="form-actions">
+      <button class="button button--dark" type="submit">Send Inquiry</button>
+      <p class="form-note" data-form-note>Send the form directly. We'll review the requirement and respond by email.</p>
+    </div>
+  </form>
+</div>
+            </div>
+          </section>
+        </main>
+        <footer class="site-footer">
+  <div class="shell site-footer__inner">
+    <div>
+      <p class="footer-label">Jade Waves Enterprise</p>
+      <p class="footer-copy">Industrial minerals, supplied with more control.</p>
+    </div>
+    <div class="footer-grid">
+      <div>
+        <p class="footer-heading">Contact</p>
+        <a href="tel:+91-999-883-5503">+91-999-883-5503</a>
+        <a href="mailto:deep@jadewavesenterprise.com">deep@jadewavesenterprise.com</a>
+      </div>
+      <div>
+        <p class="footer-heading">Navigate</p>
+        <a href="/">Home</a>
+        <a href="/products/">Products</a>
+        <a href="/operations/">Operations</a>
+        <a href="/blog/">Blog</a>
+        <a href="/hear-from-ceo/">Hear from Our CEO</a>
+        <a href="/export-markets/">Export Markets</a>
+        <a href="/#contact">Contact</a>
+      </div>
+    </div>
+  </div>
+  <div class="shell site-footer__meta">
+    <p>&copy; <span data-current-year>2026</span> Jade Waves Enterprise. All rights reserved.</p>
+  </div>
+</footer>
+              </body>
+            </html>

--- a/products/copper-slag/index.html
+++ b/products/copper-slag/index.html
@@ -1,22 +1,348 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Copper Slag Redirect | Jade Waves Enterprise</title>
-    <meta name="description" content="This product page has been consolidated into the current Jade Waves portfolio." />
-    <meta name="robots" content="noindex,follow" />
-    <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
-    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
-    <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>
-    <link rel="stylesheet" href="/styles.css" />
-  </head>
-  <body class="antialiased page-redirect">
-    <main class="shell" style="padding: 6rem 1.5rem;">
-      <p class="section-label">Redirecting</p>
-      <h1>Copper Slag Redirect | Jade Waves Enterprise</h1>
-      <p>This product page has been consolidated into the current Jade Waves portfolio.</p>
-      <p><a href="/products/">Continue to the current page</a></p>
-    </main>
-  </body>
-</html>
+            <html lang="en">
+              <head>
+                <meta charset="UTF-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                <title>Copper Slag Supplier from India for Import Buyers | Jade Waves Enterprise</title>
+                <meta name="description" content="Copper slag supplier from India for import buyers in UAE, Oman, Qatar, Bahrain, Saudi Arabia, Malaysia, and Singapore." />
+                <meta name="robots" content="index,follow" />
+                <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
+                <meta property="og:title" content="Copper Slag Supplier from India for Import Buyers | Jade Waves Enterprise" />
+                <meta property="og:description" content="Copper slag supplier from India for import buyers in UAE, Oman, Qatar, Bahrain, Saudi Arabia, Malaysia, and Singapore." />
+                <meta property="og:type" content="website" />
+                <meta property="og:url" content="https://jadewavesenterprise.com/products/copper-slag/" />
+                <meta property="og:site_name" content="Jade Waves Enterprise" />
+                <meta property="og:image" content="https://jadewavesenterprise.com/assets/jade-waves-logo-transparent.png" />
+                <link rel="preconnect" href="https://fonts.googleapis.com" />
+                <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+                <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+                <link rel="stylesheet" href="/styles.css" />
+                <script async src="https://www.googletagmanager.com/gtag/js?id=G-9BRL4JKNN6"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-9BRL4JKNN6');
+</script>
+                <script type="application/ld+json">[{"@context": "https://schema.org", "@type": "Product", "name": "Copper Slag", "description": "Copper slag supplier from India for import buyers in UAE, Oman, Qatar, Bahrain, Saudi Arabia, Malaysia, and Singapore.", "category": "Industrial Mineral", "brand": {"@type": "Brand", "name": "Jade Waves Enterprise"}, "manufacturer": {"@type": "Organization", "name": "Jade Waves Enterprise"}, "url": "https://jadewavesenterprise.com/products/copper-slag/"}, {"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "Home", "item": "https://jadewavesenterprise.com"}, {"@type": "ListItem", "position": 2, "name": "Products", "item": "https://jadewavesenterprise.com/products/"}, {"@type": "ListItem", "position": 3, "name": "Copper Slag", "item": "https://jadewavesenterprise.com/products/copper-slag/"}]}, {"@context": "https://schema.org", "@type": "FAQPage", "mainEntity": [{"@type": "Question", "name": "What applications is Copper Slag supplied for?", "acceptedAnswer": {"@type": "Answer", "text": "Copper Slag is supplied for abrasive blasting, surface preparation, and construction and concrete systems, with grade and sizing aligned to the end use."}}, {"@type": "Question", "name": "What should be confirmed before ordering Copper Slag?", "acceptedAnswer": {"@type": "Answer", "text": "Confirm sieve size distribution, density and hardness, angular grain profile, and packing and shipment volume so pricing, sampling, and dispatch can be aligned correctly."}}, {"@type": "Question", "name": "How is Copper Slag handled for export?", "acceptedAnswer": {"@type": "Answer", "text": "Supply formats include Jumbo Bags. Jade Waves aligns samples, export documents, and shipment planning from India to suit the destination and order size."}}]}]</script>
+                <script defer src="/script.js"></script>
+              </head>
+              <body class="antialiased page-product">
+                <header class="site-header" data-header>
+  <div class="site-header__inner">
+    <a class="brand-mark" href="/" aria-label="Jade Waves Enterprise home">
+      <img src="/assets/jade-waves-logo-transparent.png" alt="Jade Waves Enterprise logo" />
+    </a>
+    <nav class="desktop-nav" aria-label="Primary">
+      <a href="/#about">About</a>
+      <a href="/products/">Products</a>
+      <a href="/operations/">Operations</a>
+      <a href="/blog/">Blog</a>
+      <a href="/export-markets/">Markets</a>
+      <a href="/#contact">Contact</a>
+    </nav>
+    <div class="header-actions">
+      <a class="button button--dark button--compact" href="/#contact" data-set-request="Quote">Request Quote</a>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu" data-menu-toggle>
+        Menu
+      </button>
+    </div>
+  </div>
+  <div class="mobile-menu" id="mobile-menu" data-mobile-menu hidden>
+    <a href="/#about">About</a>
+    <a href="/products/">Products</a>
+    <a href="/operations/">Operations</a>
+    <a href="/blog/">Blog</a>
+    <a href="/export-markets/">Markets</a>
+    <a href="/#contact">Contact</a>
+  </div>
+</header>
+        <main>
+          <section class="hero hero--product theme-copper">
+            <div class="hero__strata" aria-hidden="true">
+              <span class="strata strata--a"></span>
+              <span class="strata strata--b"></span>
+              <span class="strata strata--c"></span>
+              <span class="route-line route-line--hero"></span>
+            </div>
+            <div class="shell hero__inner hero__inner--product product-hero">
+              <div class="hero-copy hero-copy--product" data-reveal>
+                <div class="breadcrumb">
+                  <a href="/">Home</a>
+                  <span>/</span>
+                  <a href="/products/">Products</a>
+                  <span>/</span>
+                  <strong>Copper Slag</strong>
+                </div>
+                <p class="hero-label">Blasting / Surface Preparation / Construction</p>
+                <h1>Copper Slag</h1>
+                <p class="hero-text">Copper slag abrasive for blasting and surface preparation where hardness, angularity, and cleaner handling matter.</p>
+                <div class="hero-actions">
+                  <a class="button button--light" href="#contact" data-set-request="Quote">Request Quote</a>
+                  <a class="button button--ghost" href="#contact" data-set-request="Sample">Request Sample</a>
+                </div>
+              </div>
+              <aside class="product-poster" data-reveal data-parallax="0.12">
+                <div class="product-poster__surface">
+                  <span class="ore-pillar ore-pillar--a"></span>
+                  <span class="ore-pillar ore-pillar--b"></span>
+                  <span class="ore-pillar ore-pillar--c"></span>
+                  <p class="product-poster__eyebrow">At a glance</p>
+                  <strong class="product-poster__title">Copper Slag</strong>
+                  <p class="product-poster__copy">Copper slag grit supplied for blasting, surface preparation, and construction use.</p>
+                  <div class="product-poster__metrics">
+                    <article class="product-poster__metric">
+  <span>Primary Use</span>
+  <strong>Abrasive blasting</strong>
+</article><article class="product-poster__metric">
+  <span>Typical Spec</span>
+  <strong>Moh&#x27;s 6.0-7.0 / Specific gravity 3.51</strong>
+</article><article class="product-poster__metric">
+  <span>Packing</span>
+  <strong>Jumbo Bags</strong>
+</article><article class="product-poster__metric">
+  <span>Shipment</span>
+  <strong>FCL</strong>
+</article>
+                  </div>
+                  <div class="product-poster__caption">
+                    <p>Sample, documents, and dispatch stay on one clear track.</p>
+                  </div>
+                  <span class="route-line route-line--snapshot"></span>
+                </div>
+              </aside>
+            </div>
+          </section>
+
+          <section class="section-block">
+
+            <div class="shell product-ledger">
+              <article class="product-sheet product-sheet--wide" data-reveal>
+                <p class="section-label">Applications</p>
+                <h2>Where it fits best.</h2>
+                <p class="product-sheet__intro">Common end uses where grade, form, and delivery have to line up.</p>
+                <div class="product-line-list"><article class="product-line">
+  <span>01</span>
+  <div>
+    <strong>Abrasive blasting</strong>
+  </div>
+</article><article class="product-line">
+  <span>02</span>
+  <div>
+    <strong>Surface preparation</strong>
+  </div>
+</article><article class="product-line">
+  <span>03</span>
+  <div>
+    <strong>Construction and concrete systems</strong>
+  </div>
+</article><article class="product-line">
+  <span>04</span>
+  <div>
+    <strong>Industrial maintenance and fabrication work</strong>
+  </div>
+</article></div>
+              </article>
+              <article class="product-sheet" data-reveal>
+                <p class="section-label">Supply Snapshot</p>
+                <h2>Supply, packing, and shipment.</h2>
+                <div class="product-info-list"><article class="product-info-row">
+  <span>Forms</span>
+  <strong>Copper slag grit</strong>
+</article><article class="product-info-row">
+  <span>Packing</span>
+  <strong>Jumbo Bags</strong>
+</article><article class="product-info-row">
+  <span>Shipment</span>
+  <strong>FCL</strong>
+</article></div>
+                <div class="form-cloud product-form-cloud"><span class="form-pill">Copper slag grit</span></div>
+              </article>
+              <article class="product-sheet product-sheet--full" data-reveal>
+  <p class="section-label">Sizes Available</p>
+  <h2>Readily Available Sizes</h2>
+  <div class="size-cloud"><span class="size-pill">4.00-3.00 mm</span><span class="size-pill">3.00-2.36 mm</span><span class="size-pill">2.36-1.00 mm</span><span class="size-pill">1.00-0.50 mm</span><span class="size-pill">0.50-0.212 mm</span><span class="size-pill">0.212 mm &amp; below</span></div>
+
+</article>
+            </div>
+          </section>
+
+          <section class="section-block section-block--contrast">
+            <div class="shell product-ledger">
+              <article class="product-sheet product-sheet--wide" data-reveal>
+                <p class="section-label">Specification Focus</p>
+                <h2>What should be confirmed.</h2>
+                <div class="product-line-list product-line-list--booking"><article class="product-line product-line--booking">
+  <span>01</span>
+  <div>
+    <strong>Sieve size distribution</strong>
+  </div>
+</article><article class="product-line product-line--booking">
+  <span>02</span>
+  <div>
+    <strong>Density and hardness</strong>
+  </div>
+</article><article class="product-line product-line--booking">
+  <span>03</span>
+  <div>
+    <strong>Angular grain profile</strong>
+  </div>
+</article><article class="product-line product-line--booking">
+  <span>04</span>
+  <div>
+    <strong>Packing and shipment volume</strong>
+  </div>
+</article></div>
+              </article>
+              <article class="product-sheet" data-reveal>
+                <p class="section-label">Commercial Fit</p>
+                <h2>Why buyers choose it.</h2>
+                <p class="product-sheet__body">For abrasive work where particle performance and dependable supply both matter.</p>
+                <div class="product-tag-cloud"><span>Blasting</span><span>Surface Preparation</span><span>Construction</span></div>
+                <div class="product-note-list"><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>Hardness reported at 6.0-7.0 on Moh&#x27;s scale</p>
+</article><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>Specific gravity reported at 3.51</p>
+</article><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>Granules are angular, sharp-edged, and multi-faced</p>
+</article><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>Electrical conductivity reported at 2 mS/m</p>
+</article></div>
+              </article>
+            </div>
+          </section>
+
+          <section class="section-block">
+            <div class="shell section-shell">
+              <div class="section-intro" data-reveal>
+                <p class="section-label">Also In The Portfolio</p>
+                <h2>More from the range.</h2>
+              </div>
+              <div class="related-links" data-reveal><a href="/products/fly-ash/">Fly Ash</a><a href="/products/silica-sand/">Silica Sand</a><a href="/products/feldspar/">Feldspar</a></div>
+            </div>
+          </section>
+
+          <section class="section-block section-block--contrast">
+            <div class="shell section-shell">
+              <div class="section-intro" data-reveal>
+                <p class="section-label">FAQ</p>
+                <h2>Questions that usually come first.</h2>
+                <p>Direct answers before pricing, sampling, and dispatch.</p>
+              </div>
+              <div class="faq-shell"><details class="faq-item" data-reveal>
+  <summary>What applications is Copper Slag supplied for?</summary>
+  <p>Copper Slag is supplied for abrasive blasting, surface preparation, and construction and concrete systems, with grade and sizing aligned to the end use.</p>
+</details><details class="faq-item" data-reveal>
+  <summary>What should be confirmed before ordering Copper Slag?</summary>
+  <p>Confirm sieve size distribution, density and hardness, angular grain profile, and packing and shipment volume so pricing, sampling, and dispatch can be aligned correctly.</p>
+</details><details class="faq-item" data-reveal>
+  <summary>How is Copper Slag handled for export?</summary>
+  <p>Supply formats include Jumbo Bags. Jade Waves aligns samples, export documents, and shipment planning from India to suit the destination and order size.</p>
+</details></div>
+            </div>
+          </section>
+
+          <section class="section-block section-block--contact">
+            <div class="shell section-shell">
+              <div class="contact-shell" id="contact">
+  <div class="contact-copy" data-reveal>
+    <p class="section-label">Contact</p>
+    <h2>Start the inquiry.</h2>
+    <p>
+      Share the product, end use, destination, and expected volume. We’ll align fit, packing, and shipment terms from there.
+    </p>
+    <div class="contact-details">
+      <a href="mailto:deep@jadewavesenterprise.com">deep@jadewavesenterprise.com</a>
+      <a href="tel:+91-999-883-5503">+91-999-883-5503</a>
+    </div>
+  </div>
+  <form class="inquiry-form" data-inquiry-form data-reveal>
+    <div class="form-grid">
+      <label>
+        <span>Request Type</span>
+        <select name="request_type">
+          <option>Quote</option>
+          <option>Sample</option>
+          <option>General Inquiry</option>
+        </select>
+      </label>
+      <label>
+        <span>Product</span>
+        <input type="text" name="product" value="Copper Slag" readonly />
+      </label>
+      <label>
+        <span>Name</span>
+        <input type="text" name="name" placeholder="Your name" required />
+      </label>
+      <label>
+        <span>Company</span>
+        <input type="text" name="company" placeholder="Company name" />
+      </label>
+      <label>
+        <span>Email</span>
+        <input type="email" name="email" placeholder="you@company.com" required />
+      </label>
+      <label>
+        <span>Phone</span>
+        <input type="text" name="phone" placeholder="+91 / country code" />
+      </label>
+      <label>
+        <span>Application</span>
+        <input type="text" name="application" placeholder="End use or industry" />
+      </label>
+      <label>
+        <span>Volume</span>
+        <input type="text" name="volume" placeholder="Trial / monthly volume" />
+      </label>
+      <label>
+        <span>Packing Size</span>
+        <input type="text" name="packing_size" placeholder="50 Kg bags / Jumbo bags / bulk" />
+      </label>
+      <label class="form-grid__wide">
+        <span>Requirement</span>
+        <textarea name="notes" rows="4" placeholder="Share grade, packing, destination, or any spec points that matter."></textarea>
+      </label>
+    </div>
+    <div class="form-actions">
+      <button class="button button--dark" type="submit">Send Inquiry</button>
+      <p class="form-note" data-form-note>Send the form directly. We'll review the requirement and respond by email.</p>
+    </div>
+  </form>
+</div>
+            </div>
+          </section>
+        </main>
+        <footer class="site-footer">
+  <div class="shell site-footer__inner">
+    <div>
+      <p class="footer-label">Jade Waves Enterprise</p>
+      <p class="footer-copy">Industrial minerals, supplied with more control.</p>
+    </div>
+    <div class="footer-grid">
+      <div>
+        <p class="footer-heading">Contact</p>
+        <a href="tel:+91-999-883-5503">+91-999-883-5503</a>
+        <a href="mailto:deep@jadewavesenterprise.com">deep@jadewavesenterprise.com</a>
+      </div>
+      <div>
+        <p class="footer-heading">Navigate</p>
+        <a href="/">Home</a>
+        <a href="/products/">Products</a>
+        <a href="/operations/">Operations</a>
+        <a href="/blog/">Blog</a>
+        <a href="/hear-from-ceo/">Hear from Our CEO</a>
+        <a href="/export-markets/">Export Markets</a>
+        <a href="/#contact">Contact</a>
+      </div>
+    </div>
+  </div>
+  <div class="shell site-footer__meta">
+    <p>&copy; <span data-current-year>2026</span> Jade Waves Enterprise. All rights reserved.</p>
+  </div>
+</footer>
+              </body>
+            </html>

--- a/products/feldspar/index.html
+++ b/products/feldspar/index.html
@@ -235,7 +235,7 @@
                 <p class="section-label">Also In The Portfolio</p>
                 <h2>More from the range.</h2>
               </div>
-              <div class="related-links" data-reveal><a href="/products/quartz-sand-for-ceramics/">Quartz Sand</a></div>
+              <div class="related-links" data-reveal><a href="/products/quartz-sand-for-ceramics/">Quartz Sand</a><a href="/products/kaolin--china-clay/">Kaolin (China Clay)</a><a href="/products/talc/">Talc</a></div>
             </div>
           </section>
 

--- a/products/fly-ash/index.html
+++ b/products/fly-ash/index.html
@@ -1,22 +1,343 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Fly Ash Redirect | Jade Waves Enterprise</title>
-    <meta name="description" content="This product page has been consolidated into the current Jade Waves portfolio." />
-    <meta name="robots" content="noindex,follow" />
-    <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
-    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
-    <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>
-    <link rel="stylesheet" href="/styles.css" />
-  </head>
-  <body class="antialiased page-redirect">
-    <main class="shell" style="padding: 6rem 1.5rem;">
-      <p class="section-label">Redirecting</p>
-      <h1>Fly Ash Redirect | Jade Waves Enterprise</h1>
-      <p>This product page has been consolidated into the current Jade Waves portfolio.</p>
-      <p><a href="/products/">Continue to the current page</a></p>
-    </main>
-  </body>
-</html>
+            <html lang="en">
+              <head>
+                <meta charset="UTF-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                <title>Fly Ash Supplier from India for Import Buyers | Jade Waves Enterprise</title>
+                <meta name="description" content="Fly ash supplier from India for import buyers in the Philippines, Malaysia, UAE, Oman, Qatar, Bahrain, and Saudi Arabia." />
+                <meta name="robots" content="index,follow" />
+                <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
+                <meta property="og:title" content="Fly Ash Supplier from India for Import Buyers | Jade Waves Enterprise" />
+                <meta property="og:description" content="Fly ash supplier from India for import buyers in the Philippines, Malaysia, UAE, Oman, Qatar, Bahrain, and Saudi Arabia." />
+                <meta property="og:type" content="website" />
+                <meta property="og:url" content="https://jadewavesenterprise.com/products/fly-ash/" />
+                <meta property="og:site_name" content="Jade Waves Enterprise" />
+                <meta property="og:image" content="https://jadewavesenterprise.com/assets/jade-waves-logo-transparent.png" />
+                <link rel="preconnect" href="https://fonts.googleapis.com" />
+                <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+                <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+                <link rel="stylesheet" href="/styles.css" />
+                <script async src="https://www.googletagmanager.com/gtag/js?id=G-9BRL4JKNN6"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-9BRL4JKNN6');
+</script>
+                <script type="application/ld+json">[{"@context": "https://schema.org", "@type": "Product", "name": "Fly Ash", "description": "Fly ash supplier from India for import buyers in the Philippines, Malaysia, UAE, Oman, Qatar, Bahrain, and Saudi Arabia.", "category": "Industrial Mineral", "brand": {"@type": "Brand", "name": "Jade Waves Enterprise"}, "manufacturer": {"@type": "Organization", "name": "Jade Waves Enterprise"}, "url": "https://jadewavesenterprise.com/products/fly-ash/"}, {"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "Home", "item": "https://jadewavesenterprise.com"}, {"@type": "ListItem", "position": 2, "name": "Products", "item": "https://jadewavesenterprise.com/products/"}, {"@type": "ListItem", "position": 3, "name": "Fly Ash", "item": "https://jadewavesenterprise.com/products/fly-ash/"}]}, {"@context": "https://schema.org", "@type": "FAQPage", "mainEntity": [{"@type": "Question", "name": "What applications is Fly Ash supplied for?", "acceptedAnswer": {"@type": "Answer", "text": "Fly Ash is supplied for cement and concrete production, fly ash bricks and blocks, and roads and embankments, with grade and sizing aligned to the end use."}}, {"@type": "Question", "name": "What should be confirmed before ordering Fly Ash?", "acceptedAnswer": {"@type": "Answer", "text": "Confirm application and replacement target, SiO2 and Al2O3 profile, packing format, and dispatch volume and schedule so pricing, sampling, and dispatch can be aligned correctly."}}, {"@type": "Question", "name": "How is Fly Ash handled for export?", "acceptedAnswer": {"@type": "Answer", "text": "Supply formats include Jumbo Bags. Jade Waves aligns samples, export documents, and shipment planning from India to suit the destination and order size."}}]}]</script>
+                <script defer src="/script.js"></script>
+              </head>
+              <body class="antialiased page-product">
+                <header class="site-header" data-header>
+  <div class="site-header__inner">
+    <a class="brand-mark" href="/" aria-label="Jade Waves Enterprise home">
+      <img src="/assets/jade-waves-logo-transparent.png" alt="Jade Waves Enterprise logo" />
+    </a>
+    <nav class="desktop-nav" aria-label="Primary">
+      <a href="/#about">About</a>
+      <a href="/products/">Products</a>
+      <a href="/operations/">Operations</a>
+      <a href="/blog/">Blog</a>
+      <a href="/export-markets/">Markets</a>
+      <a href="/#contact">Contact</a>
+    </nav>
+    <div class="header-actions">
+      <a class="button button--dark button--compact" href="/#contact" data-set-request="Quote">Request Quote</a>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu" data-menu-toggle>
+        Menu
+      </button>
+    </div>
+  </div>
+  <div class="mobile-menu" id="mobile-menu" data-mobile-menu hidden>
+    <a href="/#about">About</a>
+    <a href="/products/">Products</a>
+    <a href="/operations/">Operations</a>
+    <a href="/blog/">Blog</a>
+    <a href="/export-markets/">Markets</a>
+    <a href="/#contact">Contact</a>
+  </div>
+</header>
+        <main>
+          <section class="hero hero--product theme-ash">
+            <div class="hero__strata" aria-hidden="true">
+              <span class="strata strata--a"></span>
+              <span class="strata strata--b"></span>
+              <span class="strata strata--c"></span>
+              <span class="route-line route-line--hero"></span>
+            </div>
+            <div class="shell hero__inner hero__inner--product product-hero">
+              <div class="hero-copy hero-copy--product" data-reveal>
+                <div class="breadcrumb">
+                  <a href="/">Home</a>
+                  <span>/</span>
+                  <a href="/products/">Products</a>
+                  <span>/</span>
+                  <strong>Fly Ash</strong>
+                </div>
+                <p class="hero-label">Concrete / Cement / Blocks / Roads</p>
+                <h1>Fly Ash</h1>
+                <p class="hero-text">Fly ash for cement, concrete, blocks, and infrastructure work that depends on steady dispatch and consistent replacement performance.</p>
+                <div class="hero-actions">
+                  <a class="button button--light" href="#contact" data-set-request="Quote">Request Quote</a>
+                  <a class="button button--ghost" href="#contact" data-set-request="Sample">Request Sample</a>
+                </div>
+              </div>
+              <aside class="product-poster" data-reveal data-parallax="0.12">
+                <div class="product-poster__surface">
+                  <span class="ore-pillar ore-pillar--a"></span>
+                  <span class="ore-pillar ore-pillar--b"></span>
+                  <span class="ore-pillar ore-pillar--c"></span>
+                  <p class="product-poster__eyebrow">At a glance</p>
+                  <strong class="product-poster__title">Fly Ash</strong>
+                  <p class="product-poster__copy">Fly ash supplied for cement, concrete, blocks, and infrastructure work.</p>
+                  <div class="product-poster__metrics">
+                    <article class="product-poster__metric">
+  <span>Primary Use</span>
+  <strong>Cement and concrete production</strong>
+</article><article class="product-poster__metric">
+  <span>Typical Spec</span>
+  <strong>SiO2 55.13% / Al2O3 24.45% / LOI &lt;1%</strong>
+</article><article class="product-poster__metric">
+  <span>Packing</span>
+  <strong>Jumbo Bags</strong>
+</article><article class="product-poster__metric">
+  <span>Shipment</span>
+  <strong>FCL</strong>
+</article>
+                  </div>
+                  <div class="product-poster__caption">
+                    <p>Sample, documents, and dispatch stay on one clear track.</p>
+                  </div>
+                  <span class="route-line route-line--snapshot"></span>
+                </div>
+              </aside>
+            </div>
+          </section>
+
+          <section class="section-block">
+
+            <div class="shell product-ledger">
+              <article class="product-sheet product-sheet--wide" data-reveal>
+                <p class="section-label">Applications</p>
+                <h2>Where it fits best.</h2>
+                <p class="product-sheet__intro">Common end uses where grade, form, and delivery have to line up.</p>
+                <div class="product-line-list"><article class="product-line">
+  <span>01</span>
+  <div>
+    <strong>Cement and concrete production</strong>
+  </div>
+</article><article class="product-line">
+  <span>02</span>
+  <div>
+    <strong>Fly ash bricks and blocks</strong>
+  </div>
+</article><article class="product-line">
+  <span>03</span>
+  <div>
+    <strong>Roads and embankments</strong>
+  </div>
+</article><article class="product-line">
+  <span>04</span>
+  <div>
+    <strong>Infrastructure-linked mineral substitution</strong>
+  </div>
+</article></div>
+              </article>
+              <article class="product-sheet" data-reveal>
+                <p class="section-label">Supply Snapshot</p>
+                <h2>Supply, packing, and shipment.</h2>
+                <div class="product-info-list"><article class="product-info-row">
+  <span>Forms</span>
+  <strong>Dry fly ash and Bulk fly ash</strong>
+</article><article class="product-info-row">
+  <span>Packing</span>
+  <strong>Jumbo Bags</strong>
+</article><article class="product-info-row">
+  <span>Shipment</span>
+  <strong>FCL</strong>
+</article></div>
+                <div class="form-cloud product-form-cloud"><span class="form-pill">Dry fly ash</span><span class="form-pill">Bulk fly ash</span></div>
+              </article>
+
+            </div>
+          </section>
+
+          <section class="section-block section-block--contrast">
+            <div class="shell product-ledger">
+              <article class="product-sheet product-sheet--wide" data-reveal>
+                <p class="section-label">Specification Focus</p>
+                <h2>What should be confirmed.</h2>
+                <div class="product-line-list product-line-list--booking"><article class="product-line product-line--booking">
+  <span>01</span>
+  <div>
+    <strong>Application and replacement target</strong>
+  </div>
+</article><article class="product-line product-line--booking">
+  <span>02</span>
+  <div>
+    <strong>SiO2 and Al2O3 profile</strong>
+  </div>
+</article><article class="product-line product-line--booking">
+  <span>03</span>
+  <div>
+    <strong>Packing format</strong>
+  </div>
+</article><article class="product-line product-line--booking">
+  <span>04</span>
+  <div>
+    <strong>Dispatch volume and schedule</strong>
+  </div>
+</article></div>
+              </article>
+              <article class="product-sheet" data-reveal>
+                <p class="section-label">Commercial Fit</p>
+                <h2>Why buyers choose it.</h2>
+                <p class="product-sheet__body">For cement and infrastructure buyers who need dispatch discipline as much as material fit.</p>
+                <div class="product-tag-cloud"><span>Construction</span><span>Cement</span><span>Infrastructure</span></div>
+                <div class="product-note-list"><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>SiO2 reported at 55.13%</p>
+</article><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>Al2O3 reported at 24.45%</p>
+</article><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>Loss on ignition reported below 1%</p>
+</article><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>Residue on 45 micron sieve reported below 12%</p>
+</article></div>
+              </article>
+            </div>
+          </section>
+
+          <section class="section-block">
+            <div class="shell section-shell">
+              <div class="section-intro" data-reveal>
+                <p class="section-label">Also In The Portfolio</p>
+                <h2>More from the range.</h2>
+              </div>
+              <div class="related-links" data-reveal><a href="/products/copper-slag/">Copper Slag</a><a href="/products/silica-sand/">Silica Sand</a><a href="/products/bentonite/">Bentonite</a></div>
+            </div>
+          </section>
+
+          <section class="section-block section-block--contrast">
+            <div class="shell section-shell">
+              <div class="section-intro" data-reveal>
+                <p class="section-label">FAQ</p>
+                <h2>Questions that usually come first.</h2>
+                <p>Direct answers before pricing, sampling, and dispatch.</p>
+              </div>
+              <div class="faq-shell"><details class="faq-item" data-reveal>
+  <summary>What applications is Fly Ash supplied for?</summary>
+  <p>Fly Ash is supplied for cement and concrete production, fly ash bricks and blocks, and roads and embankments, with grade and sizing aligned to the end use.</p>
+</details><details class="faq-item" data-reveal>
+  <summary>What should be confirmed before ordering Fly Ash?</summary>
+  <p>Confirm application and replacement target, SiO2 and Al2O3 profile, packing format, and dispatch volume and schedule so pricing, sampling, and dispatch can be aligned correctly.</p>
+</details><details class="faq-item" data-reveal>
+  <summary>How is Fly Ash handled for export?</summary>
+  <p>Supply formats include Jumbo Bags. Jade Waves aligns samples, export documents, and shipment planning from India to suit the destination and order size.</p>
+</details></div>
+            </div>
+          </section>
+
+          <section class="section-block section-block--contact">
+            <div class="shell section-shell">
+              <div class="contact-shell" id="contact">
+  <div class="contact-copy" data-reveal>
+    <p class="section-label">Contact</p>
+    <h2>Start the inquiry.</h2>
+    <p>
+      Share the product, end use, destination, and expected volume. We’ll align fit, packing, and shipment terms from there.
+    </p>
+    <div class="contact-details">
+      <a href="mailto:deep@jadewavesenterprise.com">deep@jadewavesenterprise.com</a>
+      <a href="tel:+91-999-883-5503">+91-999-883-5503</a>
+    </div>
+  </div>
+  <form class="inquiry-form" data-inquiry-form data-reveal>
+    <div class="form-grid">
+      <label>
+        <span>Request Type</span>
+        <select name="request_type">
+          <option>Quote</option>
+          <option>Sample</option>
+          <option>General Inquiry</option>
+        </select>
+      </label>
+      <label>
+        <span>Product</span>
+        <input type="text" name="product" value="Fly Ash" readonly />
+      </label>
+      <label>
+        <span>Name</span>
+        <input type="text" name="name" placeholder="Your name" required />
+      </label>
+      <label>
+        <span>Company</span>
+        <input type="text" name="company" placeholder="Company name" />
+      </label>
+      <label>
+        <span>Email</span>
+        <input type="email" name="email" placeholder="you@company.com" required />
+      </label>
+      <label>
+        <span>Phone</span>
+        <input type="text" name="phone" placeholder="+91 / country code" />
+      </label>
+      <label>
+        <span>Application</span>
+        <input type="text" name="application" placeholder="End use or industry" />
+      </label>
+      <label>
+        <span>Volume</span>
+        <input type="text" name="volume" placeholder="Trial / monthly volume" />
+      </label>
+      <label>
+        <span>Packing Size</span>
+        <input type="text" name="packing_size" placeholder="50 Kg bags / Jumbo bags / bulk" />
+      </label>
+      <label class="form-grid__wide">
+        <span>Requirement</span>
+        <textarea name="notes" rows="4" placeholder="Share grade, packing, destination, or any spec points that matter."></textarea>
+      </label>
+    </div>
+    <div class="form-actions">
+      <button class="button button--dark" type="submit">Send Inquiry</button>
+      <p class="form-note" data-form-note>Send the form directly. We'll review the requirement and respond by email.</p>
+    </div>
+  </form>
+</div>
+            </div>
+          </section>
+        </main>
+        <footer class="site-footer">
+  <div class="shell site-footer__inner">
+    <div>
+      <p class="footer-label">Jade Waves Enterprise</p>
+      <p class="footer-copy">Industrial minerals, supplied with more control.</p>
+    </div>
+    <div class="footer-grid">
+      <div>
+        <p class="footer-heading">Contact</p>
+        <a href="tel:+91-999-883-5503">+91-999-883-5503</a>
+        <a href="mailto:deep@jadewavesenterprise.com">deep@jadewavesenterprise.com</a>
+      </div>
+      <div>
+        <p class="footer-heading">Navigate</p>
+        <a href="/">Home</a>
+        <a href="/products/">Products</a>
+        <a href="/operations/">Operations</a>
+        <a href="/blog/">Blog</a>
+        <a href="/hear-from-ceo/">Hear from Our CEO</a>
+        <a href="/export-markets/">Export Markets</a>
+        <a href="/#contact">Contact</a>
+      </div>
+    </div>
+  </div>
+  <div class="shell site-footer__meta">
+    <p>&copy; <span data-current-year>2026</span> Jade Waves Enterprise. All rights reserved.</p>
+  </div>
+</footer>
+              </body>
+            </html>

--- a/products/index.html
+++ b/products/index.html
@@ -24,7 +24,7 @@
   gtag('js', new Date());
   gtag('config', 'G-9BRL4JKNN6');
 </script>
-                <script type="application/ld+json">[{"@context": "https://schema.org", "@type": "CollectionPage", "name": "Jade Waves Enterprise Product Portfolio", "url": "https://jadewavesenterprise.com/products/"}, {"@context": "https://schema.org", "@type": "ItemList", "name": "Industrial Minerals", "itemListElement": [{"@type": "ListItem", "position": 1, "url": "https://jadewavesenterprise.com/products/silica-sand/", "name": "Silica Sand"}, {"@type": "ListItem", "position": 2, "url": "https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/", "name": "Quartz Sand"}, {"@type": "ListItem", "position": 3, "url": "https://jadewavesenterprise.com/products/feldspar/", "name": "Feldspar"}]}]</script>
+                <script type="application/ld+json">[{"@context": "https://schema.org", "@type": "CollectionPage", "name": "Jade Waves Enterprise Product Portfolio", "url": "https://jadewavesenterprise.com/products/"}, {"@context": "https://schema.org", "@type": "ItemList", "name": "Industrial Minerals", "itemListElement": [{"@type": "ListItem", "position": 1, "url": "https://jadewavesenterprise.com/products/silica-sand/", "name": "Silica Sand"}, {"@type": "ListItem", "position": 2, "url": "https://jadewavesenterprise.com/products/silica-flour/", "name": "Silica Flour"}, {"@type": "ListItem", "position": 3, "url": "https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/", "name": "Quartz Sand"}, {"@type": "ListItem", "position": 4, "url": "https://jadewavesenterprise.com/products/bentonite/", "name": "Bentonite"}, {"@type": "ListItem", "position": 5, "url": "https://jadewavesenterprise.com/products/kaolin--china-clay/", "name": "Kaolin (China Clay)"}, {"@type": "ListItem", "position": 6, "url": "https://jadewavesenterprise.com/products/talc/", "name": "Talc"}, {"@type": "ListItem", "position": 7, "url": "https://jadewavesenterprise.com/products/feldspar/", "name": "Feldspar"}, {"@type": "ListItem", "position": 8, "url": "https://jadewavesenterprise.com/products/salt/", "name": "Salt"}, {"@type": "ListItem", "position": 9, "url": "https://jadewavesenterprise.com/products/fly-ash/", "name": "Fly Ash"}, {"@type": "ListItem", "position": 10, "url": "https://jadewavesenterprise.com/products/copper-slag/", "name": "Copper Slag"}]}]</script>
                 <script defer src="/script.js"></script>
               </head>
               <body class="antialiased page-portfolio">
@@ -89,7 +89,7 @@
               <section class="portfolio-stage" id="silica-quartz-feldspar">
                   <div class="portfolio-stage__intro" data-reveal>
                     <p class="portfolio-stage__index">01</p>
-                    <p class="portfolio-stage__count">3 products</p>
+                    <p class="portfolio-stage__count">10 products</p>
                     <h2>Silica, Quartz &amp; Feldspar</h2>
                     <p>Purity-led grades for glass, ceramics, filtration, and engineered stone.</p>
                     <div class="portfolio-stage__focus">
@@ -105,6 +105,13 @@
     <p class="portfolio-product__fit"><span>Best for</span>Glass manufacturing and water filtration media</p>
   </div>
   <span class="portfolio-product__arrow">View product</span>
+</a><a class="portfolio-product" href="/products/silica-flour/">
+  <div class="portfolio-product__main">
+    <p class="portfolio-product__eyebrow">Ceramics / Coatings / Fillers / Construction</p>
+    <h3>Silica Flour</h3>
+    <p class="portfolio-product__fit"><span>Best for</span>Ceramics and tile bodies and paints and coatings</p>
+  </div>
+  <span class="portfolio-product__arrow">View product</span>
 </a><a class="portfolio-product" href="/products/quartz-sand-for-ceramics/">
   <div class="portfolio-product__main">
     <p class="portfolio-product__eyebrow">Ceramics / Glass / Engineered Stone / Building Materials</p>
@@ -112,11 +119,53 @@
     <p class="portfolio-product__fit"><span>Best for</span>Tiles and ceramic body production and glass manufacturing</p>
   </div>
   <span class="portfolio-product__arrow">View product</span>
+</a><a class="portfolio-product" href="/products/bentonite/">
+  <div class="portfolio-product__main">
+    <p class="portfolio-product__eyebrow">Drilling / Foundry / Civil / Absorbent Grades</p>
+    <h3>Bentonite</h3>
+    <p class="portfolio-product__fit"><span>Best for</span>Drilling fluids for oil, gas, and HDD and foundry and casting systems</p>
+  </div>
+  <span class="portfolio-product__arrow">View product</span>
+</a><a class="portfolio-product" href="/products/kaolin--china-clay/">
+  <div class="portfolio-product__main">
+    <p class="portfolio-product__eyebrow">Ceramics / Coatings / Paper / Fillers</p>
+    <h3>Kaolin (China Clay)</h3>
+    <p class="portfolio-product__fit"><span>Best for</span>Ceramics and tiles and paints and coatings</p>
+  </div>
+  <span class="portfolio-product__arrow">View product</span>
+</a><a class="portfolio-product" href="/products/talc/">
+  <div class="portfolio-product__main">
+    <p class="portfolio-product__eyebrow">Plastics / Paints / Ceramics / Rubber</p>
+    <h3>Talc</h3>
+    <p class="portfolio-product__fit"><span>Best for</span>Plastics and polymer compounds and paints and coatings</p>
+  </div>
+  <span class="portfolio-product__arrow">View product</span>
 </a><a class="portfolio-product" href="/products/feldspar/">
   <div class="portfolio-product__main">
     <p class="portfolio-product__eyebrow">Ceramics / Sanitaryware / Glass</p>
     <h3>Feldspar</h3>
     <p class="portfolio-product__fit"><span>Best for</span>Ceramic and tile production and sanitaryware manufacturing</p>
+  </div>
+  <span class="portfolio-product__arrow">View product</span>
+</a><a class="portfolio-product" href="/products/salt/">
+  <div class="portfolio-product__main">
+    <p class="portfolio-product__eyebrow">Chemical / Water Treatment / Utility / Food-Linked Supply</p>
+    <h3>Salt</h3>
+    <p class="portfolio-product__fit"><span>Best for</span>Chemical and industrial processing and water treatment applications</p>
+  </div>
+  <span class="portfolio-product__arrow">View product</span>
+</a><a class="portfolio-product" href="/products/fly-ash/">
+  <div class="portfolio-product__main">
+    <p class="portfolio-product__eyebrow">Concrete / Cement / Blocks / Roads</p>
+    <h3>Fly Ash</h3>
+    <p class="portfolio-product__fit"><span>Best for</span>Cement and concrete production and fly ash bricks and blocks</p>
+  </div>
+  <span class="portfolio-product__arrow">View product</span>
+</a><a class="portfolio-product" href="/products/copper-slag/">
+  <div class="portfolio-product__main">
+    <p class="portfolio-product__eyebrow">Blasting / Surface Preparation / Construction</p>
+    <h3>Copper Slag</h3>
+    <p class="portfolio-product__fit"><span>Best for</span>Abrasive blasting and surface preparation</p>
   </div>
   <span class="portfolio-product__arrow">View product</span>
 </a>

--- a/products/kaolin--china-clay/index.html
+++ b/products/kaolin--china-clay/index.html
@@ -1,22 +1,343 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Kaolin  China Clay Redirect | Jade Waves Enterprise</title>
-    <meta name="description" content="This product page has been consolidated into the current Jade Waves portfolio." />
-    <meta name="robots" content="noindex,follow" />
-    <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
-    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
-    <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>
-    <link rel="stylesheet" href="/styles.css" />
-  </head>
-  <body class="antialiased page-redirect">
-    <main class="shell" style="padding: 6rem 1.5rem;">
-      <p class="section-label">Redirecting</p>
-      <h1>Kaolin  China Clay Redirect | Jade Waves Enterprise</h1>
-      <p>This product page has been consolidated into the current Jade Waves portfolio.</p>
-      <p><a href="/products/">Continue to the current page</a></p>
-    </main>
-  </body>
-</html>
+            <html lang="en">
+              <head>
+                <meta charset="UTF-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                <title>China Clay Supplier from India | Kaolin Exporter | Jade Waves Enterprise</title>
+                <meta name="description" content="China clay supplier from India for import buyers in Vietnam, Thailand, Malaysia, UAE, and Saudi Arabia." />
+                <meta name="robots" content="index,follow" />
+                <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
+                <meta property="og:title" content="China Clay Supplier from India | Kaolin Exporter | Jade Waves Enterprise" />
+                <meta property="og:description" content="China clay supplier from India for import buyers in Vietnam, Thailand, Malaysia, UAE, and Saudi Arabia." />
+                <meta property="og:type" content="website" />
+                <meta property="og:url" content="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
+                <meta property="og:site_name" content="Jade Waves Enterprise" />
+                <meta property="og:image" content="https://jadewavesenterprise.com/assets/jade-waves-logo-transparent.png" />
+                <link rel="preconnect" href="https://fonts.googleapis.com" />
+                <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+                <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+                <link rel="stylesheet" href="/styles.css" />
+                <script async src="https://www.googletagmanager.com/gtag/js?id=G-9BRL4JKNN6"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-9BRL4JKNN6');
+</script>
+                <script type="application/ld+json">[{"@context": "https://schema.org", "@type": "Product", "name": "Kaolin (China Clay)", "description": "China clay supplier from India for import buyers in Vietnam, Thailand, Malaysia, UAE, and Saudi Arabia.", "category": "Industrial Mineral", "brand": {"@type": "Brand", "name": "Jade Waves Enterprise"}, "manufacturer": {"@type": "Organization", "name": "Jade Waves Enterprise"}, "url": "https://jadewavesenterprise.com/products/kaolin--china-clay/"}, {"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "Home", "item": "https://jadewavesenterprise.com"}, {"@type": "ListItem", "position": 2, "name": "Products", "item": "https://jadewavesenterprise.com/products/"}, {"@type": "ListItem", "position": 3, "name": "Kaolin (China Clay)", "item": "https://jadewavesenterprise.com/products/kaolin--china-clay/"}]}, {"@context": "https://schema.org", "@type": "FAQPage", "mainEntity": [{"@type": "Question", "name": "What applications is Kaolin (China Clay) supplied for?", "acceptedAnswer": {"@type": "Answer", "text": "Kaolin (China Clay) is supplied for ceramics and tiles, paints and coatings, and paper systems, with grade and sizing aligned to the end use."}}, {"@type": "Question", "name": "What should be confirmed before ordering Kaolin (China Clay)?", "acceptedAnswer": {"@type": "Answer", "text": "Confirm brightness target, Fe2O3 limit, Al2O3 and SiO2 profile, and form, packing, and order volume so pricing, sampling, and dispatch can be aligned correctly."}}, {"@type": "Question", "name": "How is Kaolin (China Clay) handled for export?", "acceptedAnswer": {"@type": "Answer", "text": "Supply formats include 50 Kg/Jumbo Bags. Jade Waves aligns samples, export documents, and shipment planning from India to suit the destination and order size."}}]}]</script>
+                <script defer src="/script.js"></script>
+              </head>
+              <body class="antialiased page-product">
+                <header class="site-header" data-header>
+  <div class="site-header__inner">
+    <a class="brand-mark" href="/" aria-label="Jade Waves Enterprise home">
+      <img src="/assets/jade-waves-logo-transparent.png" alt="Jade Waves Enterprise logo" />
+    </a>
+    <nav class="desktop-nav" aria-label="Primary">
+      <a href="/#about">About</a>
+      <a href="/products/">Products</a>
+      <a href="/operations/">Operations</a>
+      <a href="/blog/">Blog</a>
+      <a href="/export-markets/">Markets</a>
+      <a href="/#contact">Contact</a>
+    </nav>
+    <div class="header-actions">
+      <a class="button button--dark button--compact" href="/#contact" data-set-request="Quote">Request Quote</a>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu" data-menu-toggle>
+        Menu
+      </button>
+    </div>
+  </div>
+  <div class="mobile-menu" id="mobile-menu" data-mobile-menu hidden>
+    <a href="/#about">About</a>
+    <a href="/products/">Products</a>
+    <a href="/operations/">Operations</a>
+    <a href="/blog/">Blog</a>
+    <a href="/export-markets/">Markets</a>
+    <a href="/#contact">Contact</a>
+  </div>
+</header>
+        <main>
+          <section class="hero hero--product theme-kaolin">
+            <div class="hero__strata" aria-hidden="true">
+              <span class="strata strata--a"></span>
+              <span class="strata strata--b"></span>
+              <span class="strata strata--c"></span>
+              <span class="route-line route-line--hero"></span>
+            </div>
+            <div class="shell hero__inner hero__inner--product product-hero">
+              <div class="hero-copy hero-copy--product" data-reveal>
+                <div class="breadcrumb">
+                  <a href="/">Home</a>
+                  <span>/</span>
+                  <a href="/products/">Products</a>
+                  <span>/</span>
+                  <strong>Kaolin (China Clay)</strong>
+                </div>
+                <p class="hero-label">Ceramics / Coatings / Paper / Fillers</p>
+                <h1>Kaolin (China Clay)</h1>
+                <p class="hero-text">Kaolin with high brightness and a cleaner impurity profile for ceramics, coatings, paper, rubber, and filler systems.</p>
+                <div class="hero-actions">
+                  <a class="button button--light" href="#contact" data-set-request="Quote">Request Quote</a>
+                  <a class="button button--ghost" href="#contact" data-set-request="Sample">Request Sample</a>
+                </div>
+              </div>
+              <aside class="product-poster" data-reveal data-parallax="0.12">
+                <div class="product-poster__surface">
+                  <span class="ore-pillar ore-pillar--a"></span>
+                  <span class="ore-pillar ore-pillar--b"></span>
+                  <span class="ore-pillar ore-pillar--c"></span>
+                  <p class="product-poster__eyebrow">At a glance</p>
+                  <strong class="product-poster__title">Kaolin (China Clay)</strong>
+                  <p class="product-poster__copy">High-brightness kaolin for ceramics, coatings, paper, rubber, and fillers.</p>
+                  <div class="product-poster__metrics">
+                    <article class="product-poster__metric">
+  <span>Primary Use</span>
+  <strong>Ceramics and tiles</strong>
+</article><article class="product-poster__metric">
+  <span>Typical Spec</span>
+  <strong>Whiteness 86.17 / Fe2O3 0.29%</strong>
+</article><article class="product-poster__metric">
+  <span>Packing</span>
+  <strong>50 Kg/Jumbo Bags</strong>
+</article><article class="product-poster__metric">
+  <span>Shipment</span>
+  <strong>FCL</strong>
+</article>
+                  </div>
+                  <div class="product-poster__caption">
+                    <p>Sample, documents, and dispatch stay on one clear track.</p>
+                  </div>
+                  <span class="route-line route-line--snapshot"></span>
+                </div>
+              </aside>
+            </div>
+          </section>
+
+          <section class="section-block">
+
+            <div class="shell product-ledger">
+              <article class="product-sheet product-sheet--wide" data-reveal>
+                <p class="section-label">Applications</p>
+                <h2>Where it fits best.</h2>
+                <p class="product-sheet__intro">Common end uses where grade, form, and delivery have to line up.</p>
+                <div class="product-line-list"><article class="product-line">
+  <span>01</span>
+  <div>
+    <strong>Ceramics and tiles</strong>
+  </div>
+</article><article class="product-line">
+  <span>02</span>
+  <div>
+    <strong>Paints and coatings</strong>
+  </div>
+</article><article class="product-line">
+  <span>03</span>
+  <div>
+    <strong>Paper systems</strong>
+  </div>
+</article><article class="product-line">
+  <span>04</span>
+  <div>
+    <strong>Rubber and industrial fillers</strong>
+  </div>
+</article></div>
+              </article>
+              <article class="product-sheet" data-reveal>
+                <p class="section-label">Supply Snapshot</p>
+                <h2>Supply, packing, and shipment.</h2>
+                <div class="product-info-list"><article class="product-info-row">
+  <span>Forms</span>
+  <strong>Lumps &amp; Powder</strong>
+</article><article class="product-info-row">
+  <span>Packing</span>
+  <strong>50 Kg/Jumbo Bags</strong>
+</article><article class="product-info-row">
+  <span>Shipment</span>
+  <strong>FCL</strong>
+</article></div>
+                <div class="form-cloud product-form-cloud"><span class="form-pill">Lumps &amp; Powder</span></div>
+              </article>
+
+            </div>
+          </section>
+
+          <section class="section-block section-block--contrast">
+            <div class="shell product-ledger">
+              <article class="product-sheet product-sheet--wide" data-reveal>
+                <p class="section-label">Specification Focus</p>
+                <h2>What should be confirmed.</h2>
+                <div class="product-line-list product-line-list--booking"><article class="product-line product-line--booking">
+  <span>01</span>
+  <div>
+    <strong>Brightness target</strong>
+  </div>
+</article><article class="product-line product-line--booking">
+  <span>02</span>
+  <div>
+    <strong>Fe2O3 limit</strong>
+  </div>
+</article><article class="product-line product-line--booking">
+  <span>03</span>
+  <div>
+    <strong>Al2O3 and SiO2 profile</strong>
+  </div>
+</article><article class="product-line product-line--booking">
+  <span>04</span>
+  <div>
+    <strong>Form, packing, and order volume</strong>
+  </div>
+</article></div>
+              </article>
+              <article class="product-sheet" data-reveal>
+                <p class="section-label">Commercial Fit</p>
+                <h2>Why buyers choose it.</h2>
+                <p class="product-sheet__body">For buyers chasing brightness, cleaner firing, and a tighter filler profile.</p>
+                <div class="product-tag-cloud"><span>Ceramics</span><span>Paper</span><span>Coatings</span><span>Fillers</span></div>
+                <div class="product-note-list"><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>Whiteness reported at 86.17</p>
+</article><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>L* reported at 94.48</p>
+</article><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>Residue at 240# after 2 min grinding reported at 0.13</p>
+</article><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>Water absorption reported at 22.81%</p>
+</article></div>
+              </article>
+            </div>
+          </section>
+
+          <section class="section-block">
+            <div class="shell section-shell">
+              <div class="section-intro" data-reveal>
+                <p class="section-label">Also In The Portfolio</p>
+                <h2>More from the range.</h2>
+              </div>
+              <div class="related-links" data-reveal><a href="/products/talc/">Talc</a><a href="/products/feldspar/">Feldspar</a><a href="/products/silica-flour/">Silica Flour</a></div>
+            </div>
+          </section>
+
+          <section class="section-block section-block--contrast">
+            <div class="shell section-shell">
+              <div class="section-intro" data-reveal>
+                <p class="section-label">FAQ</p>
+                <h2>Questions that usually come first.</h2>
+                <p>Direct answers before pricing, sampling, and dispatch.</p>
+              </div>
+              <div class="faq-shell"><details class="faq-item" data-reveal>
+  <summary>What applications is Kaolin (China Clay) supplied for?</summary>
+  <p>Kaolin (China Clay) is supplied for ceramics and tiles, paints and coatings, and paper systems, with grade and sizing aligned to the end use.</p>
+</details><details class="faq-item" data-reveal>
+  <summary>What should be confirmed before ordering Kaolin (China Clay)?</summary>
+  <p>Confirm brightness target, Fe2O3 limit, Al2O3 and SiO2 profile, and form, packing, and order volume so pricing, sampling, and dispatch can be aligned correctly.</p>
+</details><details class="faq-item" data-reveal>
+  <summary>How is Kaolin (China Clay) handled for export?</summary>
+  <p>Supply formats include 50 Kg/Jumbo Bags. Jade Waves aligns samples, export documents, and shipment planning from India to suit the destination and order size.</p>
+</details></div>
+            </div>
+          </section>
+
+          <section class="section-block section-block--contact">
+            <div class="shell section-shell">
+              <div class="contact-shell" id="contact">
+  <div class="contact-copy" data-reveal>
+    <p class="section-label">Contact</p>
+    <h2>Start the inquiry.</h2>
+    <p>
+      Share the product, end use, destination, and expected volume. We’ll align fit, packing, and shipment terms from there.
+    </p>
+    <div class="contact-details">
+      <a href="mailto:deep@jadewavesenterprise.com">deep@jadewavesenterprise.com</a>
+      <a href="tel:+91-999-883-5503">+91-999-883-5503</a>
+    </div>
+  </div>
+  <form class="inquiry-form" data-inquiry-form data-reveal>
+    <div class="form-grid">
+      <label>
+        <span>Request Type</span>
+        <select name="request_type">
+          <option>Quote</option>
+          <option>Sample</option>
+          <option>General Inquiry</option>
+        </select>
+      </label>
+      <label>
+        <span>Product</span>
+        <input type="text" name="product" value="Kaolin (China Clay)" readonly />
+      </label>
+      <label>
+        <span>Name</span>
+        <input type="text" name="name" placeholder="Your name" required />
+      </label>
+      <label>
+        <span>Company</span>
+        <input type="text" name="company" placeholder="Company name" />
+      </label>
+      <label>
+        <span>Email</span>
+        <input type="email" name="email" placeholder="you@company.com" required />
+      </label>
+      <label>
+        <span>Phone</span>
+        <input type="text" name="phone" placeholder="+91 / country code" />
+      </label>
+      <label>
+        <span>Application</span>
+        <input type="text" name="application" placeholder="End use or industry" />
+      </label>
+      <label>
+        <span>Volume</span>
+        <input type="text" name="volume" placeholder="Trial / monthly volume" />
+      </label>
+      <label>
+        <span>Packing Size</span>
+        <input type="text" name="packing_size" placeholder="50 Kg bags / Jumbo bags / bulk" />
+      </label>
+      <label class="form-grid__wide">
+        <span>Requirement</span>
+        <textarea name="notes" rows="4" placeholder="Share grade, packing, destination, or any spec points that matter."></textarea>
+      </label>
+    </div>
+    <div class="form-actions">
+      <button class="button button--dark" type="submit">Send Inquiry</button>
+      <p class="form-note" data-form-note>Send the form directly. We'll review the requirement and respond by email.</p>
+    </div>
+  </form>
+</div>
+            </div>
+          </section>
+        </main>
+        <footer class="site-footer">
+  <div class="shell site-footer__inner">
+    <div>
+      <p class="footer-label">Jade Waves Enterprise</p>
+      <p class="footer-copy">Industrial minerals, supplied with more control.</p>
+    </div>
+    <div class="footer-grid">
+      <div>
+        <p class="footer-heading">Contact</p>
+        <a href="tel:+91-999-883-5503">+91-999-883-5503</a>
+        <a href="mailto:deep@jadewavesenterprise.com">deep@jadewavesenterprise.com</a>
+      </div>
+      <div>
+        <p class="footer-heading">Navigate</p>
+        <a href="/">Home</a>
+        <a href="/products/">Products</a>
+        <a href="/operations/">Operations</a>
+        <a href="/blog/">Blog</a>
+        <a href="/hear-from-ceo/">Hear from Our CEO</a>
+        <a href="/export-markets/">Export Markets</a>
+        <a href="/#contact">Contact</a>
+      </div>
+    </div>
+  </div>
+  <div class="shell site-footer__meta">
+    <p>&copy; <span data-current-year>2026</span> Jade Waves Enterprise. All rights reserved.</p>
+  </div>
+</footer>
+              </body>
+            </html>

--- a/products/quartz-sand-for-ceramics/index.html
+++ b/products/quartz-sand-for-ceramics/index.html
@@ -230,7 +230,7 @@
                 <p class="section-label">Also In The Portfolio</p>
                 <h2>More from the range.</h2>
               </div>
-              <div class="related-links" data-reveal><a href="/products/silica-sand/">Silica Sand</a><a href="/products/feldspar/">Feldspar</a></div>
+              <div class="related-links" data-reveal><a href="/products/silica-sand/">Silica Sand</a><a href="/products/silica-flour/">Silica Flour</a><a href="/products/feldspar/">Feldspar</a></div>
             </div>
           </section>
 

--- a/products/salt/index.html
+++ b/products/salt/index.html
@@ -1,22 +1,343 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Salt Redirect | Jade Waves Enterprise</title>
-    <meta name="description" content="This product page has been consolidated into the current Jade Waves portfolio." />
-    <meta name="robots" content="noindex,follow" />
-    <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
-    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
-    <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>
-    <link rel="stylesheet" href="/styles.css" />
-  </head>
-  <body class="antialiased page-redirect">
-    <main class="shell" style="padding: 6rem 1.5rem;">
-      <p class="section-label">Redirecting</p>
-      <h1>Salt Redirect | Jade Waves Enterprise</h1>
-      <p>This product page has been consolidated into the current Jade Waves portfolio.</p>
-      <p><a href="/products/">Continue to the current page</a></p>
-    </main>
-  </body>
-</html>
+            <html lang="en">
+              <head>
+                <meta charset="UTF-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                <title>Industrial Salt Supplier &amp; Exporter from India | Jade Waves Enterprise</title>
+                <meta name="description" content="Industrial salt supplier and exporter from India for water treatment, chemical processing, de-icing, and iodized salt buyers in UAE, Oman, Qatar, Bahrain, Saudi Arabia, Mauritius, and Maldives." />
+                <meta name="robots" content="index,follow" />
+                <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
+                <meta property="og:title" content="Industrial Salt Supplier &amp; Exporter from India | Jade Waves Enterprise" />
+                <meta property="og:description" content="Industrial salt supplier and exporter from India for water treatment, chemical processing, de-icing, and iodized salt buyers in UAE, Oman, Qatar, Bahrain, Saudi Arabia, Mauritius, and Maldives." />
+                <meta property="og:type" content="website" />
+                <meta property="og:url" content="https://jadewavesenterprise.com/products/salt/" />
+                <meta property="og:site_name" content="Jade Waves Enterprise" />
+                <meta property="og:image" content="https://jadewavesenterprise.com/assets/jade-waves-logo-transparent.png" />
+                <link rel="preconnect" href="https://fonts.googleapis.com" />
+                <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+                <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+                <link rel="stylesheet" href="/styles.css" />
+                <script async src="https://www.googletagmanager.com/gtag/js?id=G-9BRL4JKNN6"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-9BRL4JKNN6');
+</script>
+                <script type="application/ld+json">[{"@context": "https://schema.org", "@type": "Product", "name": "Salt", "description": "Industrial salt supplier and exporter from India for water treatment, chemical processing, de-icing, and iodized salt buyers in UAE, Oman, Qatar, Bahrain, Saudi Arabia, Mauritius, and Maldives.", "category": "Industrial Mineral", "brand": {"@type": "Brand", "name": "Jade Waves Enterprise"}, "manufacturer": {"@type": "Organization", "name": "Jade Waves Enterprise"}, "url": "https://jadewavesenterprise.com/products/salt/"}, {"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "Home", "item": "https://jadewavesenterprise.com"}, {"@type": "ListItem", "position": 2, "name": "Products", "item": "https://jadewavesenterprise.com/products/"}, {"@type": "ListItem", "position": 3, "name": "Salt", "item": "https://jadewavesenterprise.com/products/salt/"}]}, {"@context": "https://schema.org", "@type": "FAQPage", "mainEntity": [{"@type": "Question", "name": "What applications is Salt supplied for?", "acceptedAnswer": {"@type": "Answer", "text": "Salt is supplied for chemical and industrial processing, water treatment applications, and de-icing and utility use, with grade and sizing aligned to the end use."}}, {"@type": "Question", "name": "What should be confirmed before ordering Salt?", "acceptedAnswer": {"@type": "Answer", "text": "Confirm required salt grade, NaCl purity and iodine requirement, grain size, and packing and monthly volume so pricing, sampling, and dispatch can be aligned correctly."}}, {"@type": "Question", "name": "How is Salt handled for export?", "acceptedAnswer": {"@type": "Answer", "text": "Supply formats include 50 Kg/Jumbo Bags. Jade Waves aligns samples, export documents, and shipment planning from India to suit the destination and order size."}}]}]</script>
+                <script defer src="/script.js"></script>
+              </head>
+              <body class="antialiased page-product">
+                <header class="site-header" data-header>
+  <div class="site-header__inner">
+    <a class="brand-mark" href="/" aria-label="Jade Waves Enterprise home">
+      <img src="/assets/jade-waves-logo-transparent.png" alt="Jade Waves Enterprise logo" />
+    </a>
+    <nav class="desktop-nav" aria-label="Primary">
+      <a href="/#about">About</a>
+      <a href="/products/">Products</a>
+      <a href="/operations/">Operations</a>
+      <a href="/blog/">Blog</a>
+      <a href="/export-markets/">Markets</a>
+      <a href="/#contact">Contact</a>
+    </nav>
+    <div class="header-actions">
+      <a class="button button--dark button--compact" href="/#contact" data-set-request="Quote">Request Quote</a>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu" data-menu-toggle>
+        Menu
+      </button>
+    </div>
+  </div>
+  <div class="mobile-menu" id="mobile-menu" data-mobile-menu hidden>
+    <a href="/#about">About</a>
+    <a href="/products/">Products</a>
+    <a href="/operations/">Operations</a>
+    <a href="/blog/">Blog</a>
+    <a href="/export-markets/">Markets</a>
+    <a href="/#contact">Contact</a>
+  </div>
+</header>
+        <main>
+          <section class="hero hero--product theme-salt">
+            <div class="hero__strata" aria-hidden="true">
+              <span class="strata strata--a"></span>
+              <span class="strata strata--b"></span>
+              <span class="strata strata--c"></span>
+              <span class="route-line route-line--hero"></span>
+            </div>
+            <div class="shell hero__inner hero__inner--product product-hero">
+              <div class="hero-copy hero-copy--product" data-reveal>
+                <div class="breadcrumb">
+                  <a href="/">Home</a>
+                  <span>/</span>
+                  <a href="/products/">Products</a>
+                  <span>/</span>
+                  <strong>Salt</strong>
+                </div>
+                <p class="hero-label">Chemical / Water Treatment / Utility / Food-Linked Supply</p>
+                <h1>Salt</h1>
+                <p class="hero-text">Industrial and iodized salt grades for water treatment, chemical processing, infrastructure, and food-linked demand, with flexible packing and dependable export flow.</p>
+                <div class="hero-actions">
+                  <a class="button button--light" href="#contact" data-set-request="Quote">Request Quote</a>
+                  <a class="button button--ghost" href="#contact" data-set-request="Sample">Request Sample</a>
+                </div>
+              </div>
+              <aside class="product-poster" data-reveal data-parallax="0.12">
+                <div class="product-poster__surface">
+                  <span class="ore-pillar ore-pillar--a"></span>
+                  <span class="ore-pillar ore-pillar--b"></span>
+                  <span class="ore-pillar ore-pillar--c"></span>
+                  <p class="product-poster__eyebrow">At a glance</p>
+                  <strong class="product-poster__title">Salt</strong>
+                  <p class="product-poster__copy">Iodized and non-iodized salt grades for water treatment, chemical, utility, and food-linked supply.</p>
+                  <div class="product-poster__metrics">
+                    <article class="product-poster__metric">
+  <span>Primary Use</span>
+  <strong>Chemical and industrial processing</strong>
+</article><article class="product-poster__metric">
+  <span>Typical Spec</span>
+  <strong>NaCl 99.00% / Moisture 0.2% max</strong>
+</article><article class="product-poster__metric">
+  <span>Packing</span>
+  <strong>50 Kg/Jumbo Bags</strong>
+</article><article class="product-poster__metric">
+  <span>Shipment</span>
+  <strong>FCL</strong>
+</article>
+                  </div>
+                  <div class="product-poster__caption">
+                    <p>Sample, documents, and dispatch stay on one clear track.</p>
+                  </div>
+                  <span class="route-line route-line--snapshot"></span>
+                </div>
+              </aside>
+            </div>
+          </section>
+
+          <section class="section-block">
+
+            <div class="shell product-ledger">
+              <article class="product-sheet product-sheet--wide" data-reveal>
+                <p class="section-label">Applications</p>
+                <h2>Where it fits best.</h2>
+                <p class="product-sheet__intro">Common end uses where grade, form, and delivery have to line up.</p>
+                <div class="product-line-list"><article class="product-line">
+  <span>01</span>
+  <div>
+    <strong>Chemical and industrial processing</strong>
+  </div>
+</article><article class="product-line">
+  <span>02</span>
+  <div>
+    <strong>Water treatment applications</strong>
+  </div>
+</article><article class="product-line">
+  <span>03</span>
+  <div>
+    <strong>De-icing and utility use</strong>
+  </div>
+</article><article class="product-line">
+  <span>04</span>
+  <div>
+    <strong>Food processing and commercial supply</strong>
+  </div>
+</article></div>
+              </article>
+              <article class="product-sheet" data-reveal>
+                <p class="section-label">Supply Snapshot</p>
+                <h2>Supply, packing, and shipment.</h2>
+                <div class="product-info-list"><article class="product-info-row">
+  <span>Forms</span>
+  <strong>Triple refined iodized salt, Free flow iodized salt, and Industrial salt</strong>
+</article><article class="product-info-row">
+  <span>Packing</span>
+  <strong>50 Kg/Jumbo Bags</strong>
+</article><article class="product-info-row">
+  <span>Shipment</span>
+  <strong>FCL</strong>
+</article></div>
+                <div class="form-cloud product-form-cloud"><span class="form-pill">Triple refined iodized salt</span><span class="form-pill">Free flow iodized salt</span><span class="form-pill">Industrial salt</span><span class="form-pill">De-icing salt</span><span class="form-pill">Crystalline salt</span><span class="form-pill">Raw salt</span></div>
+              </article>
+
+            </div>
+          </section>
+
+          <section class="section-block section-block--contrast">
+            <div class="shell product-ledger">
+              <article class="product-sheet product-sheet--wide" data-reveal>
+                <p class="section-label">Specification Focus</p>
+                <h2>What should be confirmed.</h2>
+                <div class="product-line-list product-line-list--booking"><article class="product-line product-line--booking">
+  <span>01</span>
+  <div>
+    <strong>Required salt grade</strong>
+  </div>
+</article><article class="product-line product-line--booking">
+  <span>02</span>
+  <div>
+    <strong>NaCl purity and iodine requirement</strong>
+  </div>
+</article><article class="product-line product-line--booking">
+  <span>03</span>
+  <div>
+    <strong>Grain size</strong>
+  </div>
+</article><article class="product-line product-line--booking">
+  <span>04</span>
+  <div>
+    <strong>Packing and monthly volume</strong>
+  </div>
+</article></div>
+              </article>
+              <article class="product-sheet" data-reveal>
+                <p class="section-label">Commercial Fit</p>
+                <h2>Why buyers choose it.</h2>
+                <p class="product-sheet__body">For buyers managing multiple grades, steady volumes, and flexible packing requirements.</p>
+                <div class="product-tag-cloud"><span>Chemicals</span><span>Water Treatment</span><span>Infrastructure</span><span>Food Processing</span></div>
+                <div class="product-note-list"><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>NaCl reported at 99.00% min</p>
+</article><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>Moisture reported at 0.2% max</p>
+</article><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>Consumption salt typically carries 25-30 PPM iodine and can be customized</p>
+</article><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>Iodine is NIL for salt grades supplied outside consumption use</p>
+</article></div>
+              </article>
+            </div>
+          </section>
+
+          <section class="section-block">
+            <div class="shell section-shell">
+              <div class="section-intro" data-reveal>
+                <p class="section-label">Also In The Portfolio</p>
+                <h2>More from the range.</h2>
+              </div>
+              <div class="related-links" data-reveal><a href="/products/silica-sand/">Silica Sand</a><a href="/products/bentonite/">Bentonite</a><a href="/products/fly-ash/">Fly Ash</a></div>
+            </div>
+          </section>
+
+          <section class="section-block section-block--contrast">
+            <div class="shell section-shell">
+              <div class="section-intro" data-reveal>
+                <p class="section-label">FAQ</p>
+                <h2>Questions that usually come first.</h2>
+                <p>Direct answers before pricing, sampling, and dispatch.</p>
+              </div>
+              <div class="faq-shell"><details class="faq-item" data-reveal>
+  <summary>What applications is Salt supplied for?</summary>
+  <p>Salt is supplied for chemical and industrial processing, water treatment applications, and de-icing and utility use, with grade and sizing aligned to the end use.</p>
+</details><details class="faq-item" data-reveal>
+  <summary>What should be confirmed before ordering Salt?</summary>
+  <p>Confirm required salt grade, NaCl purity and iodine requirement, grain size, and packing and monthly volume so pricing, sampling, and dispatch can be aligned correctly.</p>
+</details><details class="faq-item" data-reveal>
+  <summary>How is Salt handled for export?</summary>
+  <p>Supply formats include 50 Kg/Jumbo Bags. Jade Waves aligns samples, export documents, and shipment planning from India to suit the destination and order size.</p>
+</details></div>
+            </div>
+          </section>
+
+          <section class="section-block section-block--contact">
+            <div class="shell section-shell">
+              <div class="contact-shell" id="contact">
+  <div class="contact-copy" data-reveal>
+    <p class="section-label">Contact</p>
+    <h2>Start the inquiry.</h2>
+    <p>
+      Share the product, end use, destination, and expected volume. We’ll align fit, packing, and shipment terms from there.
+    </p>
+    <div class="contact-details">
+      <a href="mailto:deep@jadewavesenterprise.com">deep@jadewavesenterprise.com</a>
+      <a href="tel:+91-999-883-5503">+91-999-883-5503</a>
+    </div>
+  </div>
+  <form class="inquiry-form" data-inquiry-form data-reveal>
+    <div class="form-grid">
+      <label>
+        <span>Request Type</span>
+        <select name="request_type">
+          <option>Quote</option>
+          <option>Sample</option>
+          <option>General Inquiry</option>
+        </select>
+      </label>
+      <label>
+        <span>Product</span>
+        <input type="text" name="product" value="Salt" readonly />
+      </label>
+      <label>
+        <span>Name</span>
+        <input type="text" name="name" placeholder="Your name" required />
+      </label>
+      <label>
+        <span>Company</span>
+        <input type="text" name="company" placeholder="Company name" />
+      </label>
+      <label>
+        <span>Email</span>
+        <input type="email" name="email" placeholder="you@company.com" required />
+      </label>
+      <label>
+        <span>Phone</span>
+        <input type="text" name="phone" placeholder="+91 / country code" />
+      </label>
+      <label>
+        <span>Application</span>
+        <input type="text" name="application" placeholder="End use or industry" />
+      </label>
+      <label>
+        <span>Volume</span>
+        <input type="text" name="volume" placeholder="Trial / monthly volume" />
+      </label>
+      <label>
+        <span>Packing Size</span>
+        <input type="text" name="packing_size" placeholder="50 Kg bags / Jumbo bags / bulk" />
+      </label>
+      <label class="form-grid__wide">
+        <span>Requirement</span>
+        <textarea name="notes" rows="4" placeholder="Share grade, packing, destination, or any spec points that matter."></textarea>
+      </label>
+    </div>
+    <div class="form-actions">
+      <button class="button button--dark" type="submit">Send Inquiry</button>
+      <p class="form-note" data-form-note>Send the form directly. We'll review the requirement and respond by email.</p>
+    </div>
+  </form>
+</div>
+            </div>
+          </section>
+        </main>
+        <footer class="site-footer">
+  <div class="shell site-footer__inner">
+    <div>
+      <p class="footer-label">Jade Waves Enterprise</p>
+      <p class="footer-copy">Industrial minerals, supplied with more control.</p>
+    </div>
+    <div class="footer-grid">
+      <div>
+        <p class="footer-heading">Contact</p>
+        <a href="tel:+91-999-883-5503">+91-999-883-5503</a>
+        <a href="mailto:deep@jadewavesenterprise.com">deep@jadewavesenterprise.com</a>
+      </div>
+      <div>
+        <p class="footer-heading">Navigate</p>
+        <a href="/">Home</a>
+        <a href="/products/">Products</a>
+        <a href="/operations/">Operations</a>
+        <a href="/blog/">Blog</a>
+        <a href="/hear-from-ceo/">Hear from Our CEO</a>
+        <a href="/export-markets/">Export Markets</a>
+        <a href="/#contact">Contact</a>
+      </div>
+    </div>
+  </div>
+  <div class="shell site-footer__meta">
+    <p>&copy; <span data-current-year>2026</span> Jade Waves Enterprise. All rights reserved.</p>
+  </div>
+</footer>
+              </body>
+            </html>

--- a/products/silica-flour/index.html
+++ b/products/silica-flour/index.html
@@ -1,22 +1,343 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Silica Flour Redirect | Jade Waves Enterprise</title>
-    <meta name="description" content="This product page has been consolidated into the current Jade Waves portfolio." />
-    <meta name="robots" content="noindex,follow" />
-    <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
-    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
-    <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>
-    <link rel="stylesheet" href="/styles.css" />
-  </head>
-  <body class="antialiased page-redirect">
-    <main class="shell" style="padding: 6rem 1.5rem;">
-      <p class="section-label">Redirecting</p>
-      <h1>Silica Flour Redirect | Jade Waves Enterprise</h1>
-      <p>This product page has been consolidated into the current Jade Waves portfolio.</p>
-      <p><a href="/products/silica-sand/">Continue to the current page</a></p>
-    </main>
-  </body>
-</html>
+            <html lang="en">
+              <head>
+                <meta charset="UTF-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                <title>Silica Flour Supplier from India for Import Buyers | Jade Waves Enterprise</title>
+                <meta name="description" content="Silica flour supplier from India for import buyers in Vietnam, Thailand, Malaysia, UAE, Saudi Arabia, Mauritius, and Maldives." />
+                <meta name="robots" content="index,follow" />
+                <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
+                <meta property="og:title" content="Silica Flour Supplier from India for Import Buyers | Jade Waves Enterprise" />
+                <meta property="og:description" content="Silica flour supplier from India for import buyers in Vietnam, Thailand, Malaysia, UAE, Saudi Arabia, Mauritius, and Maldives." />
+                <meta property="og:type" content="website" />
+                <meta property="og:url" content="https://jadewavesenterprise.com/products/silica-flour/" />
+                <meta property="og:site_name" content="Jade Waves Enterprise" />
+                <meta property="og:image" content="https://jadewavesenterprise.com/assets/jade-waves-logo-transparent.png" />
+                <link rel="preconnect" href="https://fonts.googleapis.com" />
+                <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+                <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+                <link rel="stylesheet" href="/styles.css" />
+                <script async src="https://www.googletagmanager.com/gtag/js?id=G-9BRL4JKNN6"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-9BRL4JKNN6');
+</script>
+                <script type="application/ld+json">[{"@context": "https://schema.org", "@type": "Product", "name": "Silica Flour", "description": "Silica flour supplier from India for import buyers in Vietnam, Thailand, Malaysia, UAE, Saudi Arabia, Mauritius, and Maldives.", "category": "Industrial Mineral", "brand": {"@type": "Brand", "name": "Jade Waves Enterprise"}, "manufacturer": {"@type": "Organization", "name": "Jade Waves Enterprise"}, "url": "https://jadewavesenterprise.com/products/silica-flour/"}, {"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "Home", "item": "https://jadewavesenterprise.com"}, {"@type": "ListItem", "position": 2, "name": "Products", "item": "https://jadewavesenterprise.com/products/"}, {"@type": "ListItem", "position": 3, "name": "Silica Flour", "item": "https://jadewavesenterprise.com/products/silica-flour/"}]}, {"@context": "https://schema.org", "@type": "FAQPage", "mainEntity": [{"@type": "Question", "name": "What applications is Silica Flour supplied for?", "acceptedAnswer": {"@type": "Answer", "text": "Silica Flour is supplied for ceramics and tile bodies, paints and coatings, and construction fillers and specialty mixes, with grade and sizing aligned to the end use."}}, {"@type": "Question", "name": "What should be confirmed before ordering Silica Flour?", "acceptedAnswer": {"@type": "Answer", "text": "Confirm mesh or micron grade, SiO2 purity, whiteness target, and packing and order volume so pricing, sampling, and dispatch can be aligned correctly."}}, {"@type": "Question", "name": "How is Silica Flour handled for export?", "acceptedAnswer": {"@type": "Answer", "text": "Supply formats include 50 Kg/Jumbo Bags. Jade Waves aligns samples, export documents, and shipment planning from India to suit the destination and order size."}}]}]</script>
+                <script defer src="/script.js"></script>
+              </head>
+              <body class="antialiased page-product">
+                <header class="site-header" data-header>
+  <div class="site-header__inner">
+    <a class="brand-mark" href="/" aria-label="Jade Waves Enterprise home">
+      <img src="/assets/jade-waves-logo-transparent.png" alt="Jade Waves Enterprise logo" />
+    </a>
+    <nav class="desktop-nav" aria-label="Primary">
+      <a href="/#about">About</a>
+      <a href="/products/">Products</a>
+      <a href="/operations/">Operations</a>
+      <a href="/blog/">Blog</a>
+      <a href="/export-markets/">Markets</a>
+      <a href="/#contact">Contact</a>
+    </nav>
+    <div class="header-actions">
+      <a class="button button--dark button--compact" href="/#contact" data-set-request="Quote">Request Quote</a>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu" data-menu-toggle>
+        Menu
+      </button>
+    </div>
+  </div>
+  <div class="mobile-menu" id="mobile-menu" data-mobile-menu hidden>
+    <a href="/#about">About</a>
+    <a href="/products/">Products</a>
+    <a href="/operations/">Operations</a>
+    <a href="/blog/">Blog</a>
+    <a href="/export-markets/">Markets</a>
+    <a href="/#contact">Contact</a>
+  </div>
+</header>
+        <main>
+          <section class="hero hero--product theme-silica">
+            <div class="hero__strata" aria-hidden="true">
+              <span class="strata strata--a"></span>
+              <span class="strata strata--b"></span>
+              <span class="strata strata--c"></span>
+              <span class="route-line route-line--hero"></span>
+            </div>
+            <div class="shell hero__inner hero__inner--product product-hero">
+              <div class="hero-copy hero-copy--product" data-reveal>
+                <div class="breadcrumb">
+                  <a href="/">Home</a>
+                  <span>/</span>
+                  <a href="/products/">Products</a>
+                  <span>/</span>
+                  <strong>Silica Flour</strong>
+                </div>
+                <p class="hero-label">Ceramics / Coatings / Fillers / Construction</p>
+                <h1>Silica Flour</h1>
+                <p class="hero-text">Silica flour with controlled sizing for ceramics, coatings, fillers, sealants, and construction systems that depend on a reliable micron profile.</p>
+                <div class="hero-actions">
+                  <a class="button button--light" href="#contact" data-set-request="Quote">Request Quote</a>
+                  <a class="button button--ghost" href="#contact" data-set-request="Sample">Request Sample</a>
+                </div>
+              </div>
+              <aside class="product-poster" data-reveal data-parallax="0.12">
+                <div class="product-poster__surface">
+                  <span class="ore-pillar ore-pillar--a"></span>
+                  <span class="ore-pillar ore-pillar--b"></span>
+                  <span class="ore-pillar ore-pillar--c"></span>
+                  <p class="product-poster__eyebrow">At a glance</p>
+                  <strong class="product-poster__title">Silica Flour</strong>
+                  <p class="product-poster__copy">Controlled-size silica flour for ceramics, coatings, fillers, and specialty construction.</p>
+                  <div class="product-poster__metrics">
+                    <article class="product-poster__metric">
+  <span>Primary Use</span>
+  <strong>Ceramics and tile bodies</strong>
+</article><article class="product-poster__metric">
+  <span>Typical Spec</span>
+  <strong>SiO2 99.10% / Fe2O3 0.036%</strong>
+</article><article class="product-poster__metric">
+  <span>Packing</span>
+  <strong>50 Kg/Jumbo Bags</strong>
+</article><article class="product-poster__metric">
+  <span>Shipment</span>
+  <strong>FCL</strong>
+</article>
+                  </div>
+                  <div class="product-poster__caption">
+                    <p>Sample, documents, and dispatch stay on one clear track.</p>
+                  </div>
+                  <span class="route-line route-line--snapshot"></span>
+                </div>
+              </aside>
+            </div>
+          </section>
+
+          <section class="section-block">
+
+            <div class="shell product-ledger">
+              <article class="product-sheet product-sheet--wide" data-reveal>
+                <p class="section-label">Applications</p>
+                <h2>Where it fits best.</h2>
+                <p class="product-sheet__intro">Common end uses where grade, form, and delivery have to line up.</p>
+                <div class="product-line-list"><article class="product-line">
+  <span>01</span>
+  <div>
+    <strong>Ceramics and tile bodies</strong>
+  </div>
+</article><article class="product-line">
+  <span>02</span>
+  <div>
+    <strong>Paints and coatings</strong>
+  </div>
+</article><article class="product-line">
+  <span>03</span>
+  <div>
+    <strong>Construction fillers and specialty mixes</strong>
+  </div>
+</article><article class="product-line">
+  <span>04</span>
+  <div>
+    <strong>Oil well cementing and sealant systems</strong>
+  </div>
+</article></div>
+              </article>
+              <article class="product-sheet" data-reveal>
+                <p class="section-label">Supply Snapshot</p>
+                <h2>Supply, packing, and shipment.</h2>
+                <div class="product-info-list"><article class="product-info-row">
+  <span>Forms</span>
+  <strong>80 mesh silica flour, 300 mesh silica flour, and 500 mesh silica flour</strong>
+</article><article class="product-info-row">
+  <span>Packing</span>
+  <strong>50 Kg/Jumbo Bags</strong>
+</article><article class="product-info-row">
+  <span>Shipment</span>
+  <strong>FCL</strong>
+</article></div>
+                <div class="form-cloud product-form-cloud"><span class="form-pill">80 mesh silica flour</span><span class="form-pill">300 mesh silica flour</span><span class="form-pill">500 mesh silica flour</span><span class="form-pill">Custom micron grading</span></div>
+              </article>
+
+            </div>
+          </section>
+
+          <section class="section-block section-block--contrast">
+            <div class="shell product-ledger">
+              <article class="product-sheet product-sheet--wide" data-reveal>
+                <p class="section-label">Specification Focus</p>
+                <h2>What should be confirmed.</h2>
+                <div class="product-line-list product-line-list--booking"><article class="product-line product-line--booking">
+  <span>01</span>
+  <div>
+    <strong>Mesh or micron grade</strong>
+  </div>
+</article><article class="product-line product-line--booking">
+  <span>02</span>
+  <div>
+    <strong>SiO2 purity</strong>
+  </div>
+</article><article class="product-line product-line--booking">
+  <span>03</span>
+  <div>
+    <strong>Whiteness target</strong>
+  </div>
+</article><article class="product-line product-line--booking">
+  <span>04</span>
+  <div>
+    <strong>Packing and order volume</strong>
+  </div>
+</article></div>
+              </article>
+              <article class="product-sheet" data-reveal>
+                <p class="section-label">Commercial Fit</p>
+                <h2>Why buyers choose it.</h2>
+                <p class="product-sheet__body">For buyers who care more about particle discipline than generic silica supply.</p>
+                <div class="product-tag-cloud"><span>Ceramics</span><span>Construction</span><span>Coatings</span><span>Chemicals</span></div>
+                <div class="product-note-list"><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>SiO2 reported at 99.10%</p>
+</article><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>Fe2O3 reported at 0.036%</p>
+</article><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>Al2O3 reported at 0.49%</p>
+</article><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>TiO2 reported at 0.018%</p>
+</article></div>
+              </article>
+            </div>
+          </section>
+
+          <section class="section-block">
+            <div class="shell section-shell">
+              <div class="section-intro" data-reveal>
+                <p class="section-label">Also In The Portfolio</p>
+                <h2>More from the range.</h2>
+              </div>
+              <div class="related-links" data-reveal><a href="/products/silica-sand/">Silica Sand</a><a href="/products/quartz-sand-for-ceramics/">Quartz Sand</a><a href="/products/kaolin--china-clay/">Kaolin (China Clay)</a></div>
+            </div>
+          </section>
+
+          <section class="section-block section-block--contrast">
+            <div class="shell section-shell">
+              <div class="section-intro" data-reveal>
+                <p class="section-label">FAQ</p>
+                <h2>Questions that usually come first.</h2>
+                <p>Direct answers before pricing, sampling, and dispatch.</p>
+              </div>
+              <div class="faq-shell"><details class="faq-item" data-reveal>
+  <summary>What applications is Silica Flour supplied for?</summary>
+  <p>Silica Flour is supplied for ceramics and tile bodies, paints and coatings, and construction fillers and specialty mixes, with grade and sizing aligned to the end use.</p>
+</details><details class="faq-item" data-reveal>
+  <summary>What should be confirmed before ordering Silica Flour?</summary>
+  <p>Confirm mesh or micron grade, SiO2 purity, whiteness target, and packing and order volume so pricing, sampling, and dispatch can be aligned correctly.</p>
+</details><details class="faq-item" data-reveal>
+  <summary>How is Silica Flour handled for export?</summary>
+  <p>Supply formats include 50 Kg/Jumbo Bags. Jade Waves aligns samples, export documents, and shipment planning from India to suit the destination and order size.</p>
+</details></div>
+            </div>
+          </section>
+
+          <section class="section-block section-block--contact">
+            <div class="shell section-shell">
+              <div class="contact-shell" id="contact">
+  <div class="contact-copy" data-reveal>
+    <p class="section-label">Contact</p>
+    <h2>Start the inquiry.</h2>
+    <p>
+      Share the product, end use, destination, and expected volume. We’ll align fit, packing, and shipment terms from there.
+    </p>
+    <div class="contact-details">
+      <a href="mailto:deep@jadewavesenterprise.com">deep@jadewavesenterprise.com</a>
+      <a href="tel:+91-999-883-5503">+91-999-883-5503</a>
+    </div>
+  </div>
+  <form class="inquiry-form" data-inquiry-form data-reveal>
+    <div class="form-grid">
+      <label>
+        <span>Request Type</span>
+        <select name="request_type">
+          <option>Quote</option>
+          <option>Sample</option>
+          <option>General Inquiry</option>
+        </select>
+      </label>
+      <label>
+        <span>Product</span>
+        <input type="text" name="product" value="Silica Flour" readonly />
+      </label>
+      <label>
+        <span>Name</span>
+        <input type="text" name="name" placeholder="Your name" required />
+      </label>
+      <label>
+        <span>Company</span>
+        <input type="text" name="company" placeholder="Company name" />
+      </label>
+      <label>
+        <span>Email</span>
+        <input type="email" name="email" placeholder="you@company.com" required />
+      </label>
+      <label>
+        <span>Phone</span>
+        <input type="text" name="phone" placeholder="+91 / country code" />
+      </label>
+      <label>
+        <span>Application</span>
+        <input type="text" name="application" placeholder="End use or industry" />
+      </label>
+      <label>
+        <span>Volume</span>
+        <input type="text" name="volume" placeholder="Trial / monthly volume" />
+      </label>
+      <label>
+        <span>Packing Size</span>
+        <input type="text" name="packing_size" placeholder="50 Kg bags / Jumbo bags / bulk" />
+      </label>
+      <label class="form-grid__wide">
+        <span>Requirement</span>
+        <textarea name="notes" rows="4" placeholder="Share grade, packing, destination, or any spec points that matter."></textarea>
+      </label>
+    </div>
+    <div class="form-actions">
+      <button class="button button--dark" type="submit">Send Inquiry</button>
+      <p class="form-note" data-form-note>Send the form directly. We'll review the requirement and respond by email.</p>
+    </div>
+  </form>
+</div>
+            </div>
+          </section>
+        </main>
+        <footer class="site-footer">
+  <div class="shell site-footer__inner">
+    <div>
+      <p class="footer-label">Jade Waves Enterprise</p>
+      <p class="footer-copy">Industrial minerals, supplied with more control.</p>
+    </div>
+    <div class="footer-grid">
+      <div>
+        <p class="footer-heading">Contact</p>
+        <a href="tel:+91-999-883-5503">+91-999-883-5503</a>
+        <a href="mailto:deep@jadewavesenterprise.com">deep@jadewavesenterprise.com</a>
+      </div>
+      <div>
+        <p class="footer-heading">Navigate</p>
+        <a href="/">Home</a>
+        <a href="/products/">Products</a>
+        <a href="/operations/">Operations</a>
+        <a href="/blog/">Blog</a>
+        <a href="/hear-from-ceo/">Hear from Our CEO</a>
+        <a href="/export-markets/">Export Markets</a>
+        <a href="/#contact">Contact</a>
+      </div>
+    </div>
+  </div>
+  <div class="shell site-footer__meta">
+    <p>&copy; <span data-current-year>2026</span> Jade Waves Enterprise. All rights reserved.</p>
+  </div>
+</footer>
+              </body>
+            </html>

--- a/products/silica-sand/index.html
+++ b/products/silica-sand/index.html
@@ -249,7 +249,7 @@
                 <p class="section-label">Also In The Portfolio</p>
                 <h2>More from the range.</h2>
               </div>
-              <div class="related-links" data-reveal><a href="/products/quartz-sand-for-ceramics/">Quartz Sand</a><a href="/products/feldspar/">Feldspar</a></div>
+              <div class="related-links" data-reveal><a href="/products/silica-flour/">Silica Flour</a><a href="/products/quartz-sand-for-ceramics/">Quartz Sand</a><a href="/products/feldspar/">Feldspar</a></div>
             </div>
           </section>
 

--- a/products/talc/index.html
+++ b/products/talc/index.html
@@ -1,22 +1,358 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Talc Redirect | Jade Waves Enterprise</title>
-    <meta name="description" content="This product page has been consolidated into the current Jade Waves portfolio." />
-    <meta name="robots" content="noindex,follow" />
-    <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
-    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
-    <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>
-    <link rel="stylesheet" href="/styles.css" />
-  </head>
-  <body class="antialiased page-redirect">
-    <main class="shell" style="padding: 6rem 1.5rem;">
-      <p class="section-label">Redirecting</p>
-      <h1>Talc Redirect | Jade Waves Enterprise</h1>
-      <p>This product page has been consolidated into the current Jade Waves portfolio.</p>
-      <p><a href="/products/">Continue to the current page</a></p>
-    </main>
-  </body>
-</html>
+            <html lang="en">
+              <head>
+                <meta charset="UTF-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                <title>Talc Powder Supplier from India for Import Buyers | Jade Waves Enterprise</title>
+                <meta name="description" content="Talc powder supplier from India for import buyers in Vietnam, Thailand, Malaysia, UAE, Oman, Qatar, Bahrain, and Saudi Arabia." />
+                <meta name="robots" content="index,follow" />
+                <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
+                <meta property="og:title" content="Talc Powder Supplier from India for Import Buyers | Jade Waves Enterprise" />
+                <meta property="og:description" content="Talc powder supplier from India for import buyers in Vietnam, Thailand, Malaysia, UAE, Oman, Qatar, Bahrain, and Saudi Arabia." />
+                <meta property="og:type" content="website" />
+                <meta property="og:url" content="https://jadewavesenterprise.com/products/talc/" />
+                <meta property="og:site_name" content="Jade Waves Enterprise" />
+                <meta property="og:image" content="https://jadewavesenterprise.com/assets/jade-waves-logo-transparent.png" />
+                <link rel="preconnect" href="https://fonts.googleapis.com" />
+                <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+                <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+                <link rel="stylesheet" href="/styles.css" />
+                <script async src="https://www.googletagmanager.com/gtag/js?id=G-9BRL4JKNN6"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-9BRL4JKNN6');
+</script>
+                <script type="application/ld+json">[{"@context": "https://schema.org", "@type": "Product", "name": "Talc", "description": "Talc powder supplier from India for import buyers in Vietnam, Thailand, Malaysia, UAE, Oman, Qatar, Bahrain, and Saudi Arabia.", "category": "Industrial Mineral", "brand": {"@type": "Brand", "name": "Jade Waves Enterprise"}, "manufacturer": {"@type": "Organization", "name": "Jade Waves Enterprise"}, "url": "https://jadewavesenterprise.com/products/talc/"}, {"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "Home", "item": "https://jadewavesenterprise.com"}, {"@type": "ListItem", "position": 2, "name": "Products", "item": "https://jadewavesenterprise.com/products/"}, {"@type": "ListItem", "position": 3, "name": "Talc", "item": "https://jadewavesenterprise.com/products/talc/"}]}, {"@context": "https://schema.org", "@type": "FAQPage", "mainEntity": [{"@type": "Question", "name": "What applications is Talc supplied for?", "acceptedAnswer": {"@type": "Answer", "text": "Talc is supplied for plastics and polymer compounds, paints and coatings, and ceramics, with grade and sizing aligned to the end use."}}, {"@type": "Question", "name": "What should be confirmed before ordering Talc?", "acceptedAnswer": {"@type": "Answer", "text": "Confirm form & Grain/Mesh Size, whiteness target, MgO and SiO2 profile, and packing and order volume so pricing, sampling, and dispatch can be aligned correctly."}}, {"@type": "Question", "name": "How is Talc handled for export?", "acceptedAnswer": {"@type": "Answer", "text": "Supply formats include Jumbo Bags. Jade Waves aligns samples, export documents, and shipment planning from India to suit the destination and order size."}}]}]</script>
+                <script defer src="/script.js"></script>
+              </head>
+              <body class="antialiased page-product">
+                <header class="site-header" data-header>
+  <div class="site-header__inner">
+    <a class="brand-mark" href="/" aria-label="Jade Waves Enterprise home">
+      <img src="/assets/jade-waves-logo-transparent.png" alt="Jade Waves Enterprise logo" />
+    </a>
+    <nav class="desktop-nav" aria-label="Primary">
+      <a href="/#about">About</a>
+      <a href="/products/">Products</a>
+      <a href="/operations/">Operations</a>
+      <a href="/blog/">Blog</a>
+      <a href="/export-markets/">Markets</a>
+      <a href="/#contact">Contact</a>
+    </nav>
+    <div class="header-actions">
+      <a class="button button--dark button--compact" href="/#contact" data-set-request="Quote">Request Quote</a>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu" data-menu-toggle>
+        Menu
+      </button>
+    </div>
+  </div>
+  <div class="mobile-menu" id="mobile-menu" data-mobile-menu hidden>
+    <a href="/#about">About</a>
+    <a href="/products/">Products</a>
+    <a href="/operations/">Operations</a>
+    <a href="/blog/">Blog</a>
+    <a href="/export-markets/">Markets</a>
+    <a href="/#contact">Contact</a>
+  </div>
+</header>
+        <main>
+          <section class="hero hero--product theme-talc">
+            <div class="hero__strata" aria-hidden="true">
+              <span class="strata strata--a"></span>
+              <span class="strata strata--b"></span>
+              <span class="strata strata--c"></span>
+              <span class="route-line route-line--hero"></span>
+            </div>
+            <div class="shell hero__inner hero__inner--product product-hero">
+              <div class="hero-copy hero-copy--product" data-reveal>
+                <div class="breadcrumb">
+                  <a href="/">Home</a>
+                  <span>/</span>
+                  <a href="/products/">Products</a>
+                  <span>/</span>
+                  <strong>Talc</strong>
+                </div>
+                <p class="hero-label">Plastics / Paints / Ceramics / Rubber</p>
+                <h1>Talc</h1>
+                <p class="hero-text">Talc powder for plastics, paints, ceramics, rubber, cable, detergents, and fillers where whiteness, fineness, and smoother processing matter.</p>
+                <div class="hero-actions">
+                  <a class="button button--light" href="#contact" data-set-request="Quote">Request Quote</a>
+                  <a class="button button--ghost" href="#contact" data-set-request="Sample">Request Sample</a>
+                </div>
+              </div>
+              <aside class="product-poster" data-reveal data-parallax="0.12">
+                <div class="product-poster__surface">
+                  <span class="ore-pillar ore-pillar--a"></span>
+                  <span class="ore-pillar ore-pillar--b"></span>
+                  <span class="ore-pillar ore-pillar--c"></span>
+                  <p class="product-poster__eyebrow">At a glance</p>
+                  <strong class="product-poster__title">Talc</strong>
+                  <p class="product-poster__copy">High-whiteness talc powder for plastics, coatings, ceramics, rubber, cable, detergents, and fillers.</p>
+                  <div class="product-poster__metrics">
+                    <article class="product-poster__metric">
+  <span>Primary Use</span>
+  <strong>Plastics and polymer compounds</strong>
+</article><article class="product-poster__metric">
+  <span>Specification</span>
+  <strong>Form &amp; Grain/Mesh Size</strong>
+</article><article class="product-poster__metric">
+  <span>Packing</span>
+  <strong>Jumbo Bags</strong>
+</article><article class="product-poster__metric">
+  <span>Shipment</span>
+  <strong>FCL</strong>
+</article>
+                  </div>
+                  <div class="product-poster__caption">
+                    <p>Sample, documents, and dispatch stay on one clear track.</p>
+                  </div>
+                  <span class="route-line route-line--snapshot"></span>
+                </div>
+              </aside>
+            </div>
+          </section>
+
+          <section class="section-block">
+
+            <div class="shell product-ledger">
+              <article class="product-sheet product-sheet--wide" data-reveal>
+                <p class="section-label">Applications</p>
+                <h2>Where it fits best.</h2>
+                <p class="product-sheet__intro">Common end uses where grade, form, and delivery have to line up.</p>
+                <div class="product-line-list"><article class="product-line">
+  <span>01</span>
+  <div>
+    <strong>Plastics and polymer compounds</strong>
+  </div>
+</article><article class="product-line">
+  <span>02</span>
+  <div>
+    <strong>Paints and coatings</strong>
+  </div>
+</article><article class="product-line">
+  <span>03</span>
+  <div>
+    <strong>Ceramics</strong>
+  </div>
+</article><article class="product-line">
+  <span>04</span>
+  <div>
+    <strong>Rubber and industrial fillers</strong>
+  </div>
+</article><article class="product-line">
+  <span>05</span>
+  <div>
+    <strong>Detergents and soaps</strong>
+  </div>
+</article><article class="product-line">
+  <span>06</span>
+  <div>
+    <strong>Cables and wire compounds</strong>
+  </div>
+</article><article class="product-line">
+  <span>07</span>
+  <div>
+    <strong>Pharma and drug filler use</strong>
+  </div>
+</article></div>
+              </article>
+              <article class="product-sheet" data-reveal>
+                <p class="section-label">Supply Snapshot</p>
+                <h2>Supply, packing, and shipment.</h2>
+                <div class="product-info-list"><article class="product-info-row">
+  <span>Forms</span>
+  <strong>Talc powder in application-specific mesh sizes</strong>
+</article><article class="product-info-row">
+  <span>Packing</span>
+  <strong>Jumbo Bags</strong>
+</article><article class="product-info-row">
+  <span>Shipment</span>
+  <strong>FCL</strong>
+</article></div>
+                <div class="form-cloud product-form-cloud"><span class="form-pill">Talc powder in application-specific mesh sizes</span></div>
+              </article>
+
+            </div>
+          </section>
+
+          <section class="section-block section-block--contrast">
+            <div class="shell product-ledger">
+              <article class="product-sheet product-sheet--wide" data-reveal>
+                <p class="section-label">Specification Focus</p>
+                <h2>What should be confirmed.</h2>
+                <div class="product-line-list product-line-list--booking"><article class="product-line product-line--booking">
+  <span>01</span>
+  <div>
+    <strong>Form &amp; Grain/Mesh Size</strong>
+  </div>
+</article><article class="product-line product-line--booking">
+  <span>02</span>
+  <div>
+    <strong>Whiteness target</strong>
+  </div>
+</article><article class="product-line product-line--booking">
+  <span>03</span>
+  <div>
+    <strong>MgO and SiO2 profile</strong>
+  </div>
+</article><article class="product-line product-line--booking">
+  <span>04</span>
+  <div>
+    <strong>Packing and order volume</strong>
+  </div>
+</article></div>
+              </article>
+              <article class="product-sheet" data-reveal>
+                <p class="section-label">Commercial Fit</p>
+                <h2>Why buyers choose it.</h2>
+                <p class="product-sheet__body">For formulations that depend on whiteness, smoothness, and finer control.</p>
+                <div class="product-tag-cloud"><span>Plastics</span><span>Coatings</span><span>Ceramics</span><span>Rubber</span></div>
+                <div class="product-note-list"><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>High whiteness</p>
+</article><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>Ultra-fine particle size</p>
+</article><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>Smoothness in processing</p>
+</article><article class="product-note">
+  <span aria-hidden="true"></span>
+  <p>Chemical stability</p>
+</article></div>
+              </article>
+            </div>
+          </section>
+
+          <section class="section-block">
+            <div class="shell section-shell">
+              <div class="section-intro" data-reveal>
+                <p class="section-label">Also In The Portfolio</p>
+                <h2>More from the range.</h2>
+              </div>
+              <div class="related-links" data-reveal><a href="/products/kaolin--china-clay/">Kaolin (China Clay)</a><a href="/products/feldspar/">Feldspar</a><a href="/products/silica-flour/">Silica Flour</a></div>
+            </div>
+          </section>
+
+          <section class="section-block section-block--contrast">
+            <div class="shell section-shell">
+              <div class="section-intro" data-reveal>
+                <p class="section-label">FAQ</p>
+                <h2>Questions that usually come first.</h2>
+                <p>Direct answers before pricing, sampling, and dispatch.</p>
+              </div>
+              <div class="faq-shell"><details class="faq-item" data-reveal>
+  <summary>What applications is Talc supplied for?</summary>
+  <p>Talc is supplied for plastics and polymer compounds, paints and coatings, and ceramics, with grade and sizing aligned to the end use.</p>
+</details><details class="faq-item" data-reveal>
+  <summary>What should be confirmed before ordering Talc?</summary>
+  <p>Confirm form &amp; Grain/Mesh Size, whiteness target, MgO and SiO2 profile, and packing and order volume so pricing, sampling, and dispatch can be aligned correctly.</p>
+</details><details class="faq-item" data-reveal>
+  <summary>How is Talc handled for export?</summary>
+  <p>Supply formats include Jumbo Bags. Jade Waves aligns samples, export documents, and shipment planning from India to suit the destination and order size.</p>
+</details></div>
+            </div>
+          </section>
+
+          <section class="section-block section-block--contact">
+            <div class="shell section-shell">
+              <div class="contact-shell" id="contact">
+  <div class="contact-copy" data-reveal>
+    <p class="section-label">Contact</p>
+    <h2>Start the inquiry.</h2>
+    <p>
+      Share the product, end use, destination, and expected volume. We’ll align fit, packing, and shipment terms from there.
+    </p>
+    <div class="contact-details">
+      <a href="mailto:deep@jadewavesenterprise.com">deep@jadewavesenterprise.com</a>
+      <a href="tel:+91-999-883-5503">+91-999-883-5503</a>
+    </div>
+  </div>
+  <form class="inquiry-form" data-inquiry-form data-reveal>
+    <div class="form-grid">
+      <label>
+        <span>Request Type</span>
+        <select name="request_type">
+          <option>Quote</option>
+          <option>Sample</option>
+          <option>General Inquiry</option>
+        </select>
+      </label>
+      <label>
+        <span>Product</span>
+        <input type="text" name="product" value="Talc" readonly />
+      </label>
+      <label>
+        <span>Name</span>
+        <input type="text" name="name" placeholder="Your name" required />
+      </label>
+      <label>
+        <span>Company</span>
+        <input type="text" name="company" placeholder="Company name" />
+      </label>
+      <label>
+        <span>Email</span>
+        <input type="email" name="email" placeholder="you@company.com" required />
+      </label>
+      <label>
+        <span>Phone</span>
+        <input type="text" name="phone" placeholder="+91 / country code" />
+      </label>
+      <label>
+        <span>Application</span>
+        <input type="text" name="application" placeholder="End use or industry" />
+      </label>
+      <label>
+        <span>Volume</span>
+        <input type="text" name="volume" placeholder="Trial / monthly volume" />
+      </label>
+      <label>
+        <span>Packing Size</span>
+        <input type="text" name="packing_size" placeholder="50 Kg bags / Jumbo bags / bulk" />
+      </label>
+      <label class="form-grid__wide">
+        <span>Requirement</span>
+        <textarea name="notes" rows="4" placeholder="Share grade, packing, destination, or any spec points that matter."></textarea>
+      </label>
+    </div>
+    <div class="form-actions">
+      <button class="button button--dark" type="submit">Send Inquiry</button>
+      <p class="form-note" data-form-note>Send the form directly. We'll review the requirement and respond by email.</p>
+    </div>
+  </form>
+</div>
+            </div>
+          </section>
+        </main>
+        <footer class="site-footer">
+  <div class="shell site-footer__inner">
+    <div>
+      <p class="footer-label">Jade Waves Enterprise</p>
+      <p class="footer-copy">Industrial minerals, supplied with more control.</p>
+    </div>
+    <div class="footer-grid">
+      <div>
+        <p class="footer-heading">Contact</p>
+        <a href="tel:+91-999-883-5503">+91-999-883-5503</a>
+        <a href="mailto:deep@jadewavesenterprise.com">deep@jadewavesenterprise.com</a>
+      </div>
+      <div>
+        <p class="footer-heading">Navigate</p>
+        <a href="/">Home</a>
+        <a href="/products/">Products</a>
+        <a href="/operations/">Operations</a>
+        <a href="/blog/">Blog</a>
+        <a href="/hear-from-ceo/">Hear from Our CEO</a>
+        <a href="/export-markets/">Export Markets</a>
+        <a href="/#contact">Contact</a>
+      </div>
+    </div>
+  </div>
+  <div class="shell site-footer__meta">
+    <p>&copy; <span data-current-year>2026</span> Jade Waves Enterprise. All rights reserved.</p>
+  </div>
+</footer>
+              </body>
+            </html>

--- a/quartz-sand-for-ceramics/index.html
+++ b/quartz-sand-for-ceramics/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Quartz Sand moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Quartz sand moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
-    <meta http-equiv="refresh" content="0; url=/products/quartz-sand-for-ceramics/" />
-    <script>window.location.replace("/products/quartz-sand-for-ceramics/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Quartz Sand moved to <a href="/products/quartz-sand-for-ceramics/">https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Quartz sand moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/quartz-sand-for-ceramics/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/quartz/index.html
+++ b/quartz/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Quartz page moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Quartz moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
-    <meta http-equiv="refresh" content="0; url=/products/quartz-sand-for-ceramics/" />
-    <script>window.location.replace("/products/quartz-sand-for-ceramics/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Quartz page moved to <a href="/products/quartz-sand-for-ceramics/">https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Quartz moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/quartz-sand-for-ceramics/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/refractory-bentonite/index.html
+++ b/refractory-bentonite/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Refractory bentonite page moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Refractory bentonite moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
-    <meta http-equiv="refresh" content="0; url=/products/bentonite/" />
-    <script>window.location.replace("/products/bentonite/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Refractory bentonite page moved to <a href="/products/bentonite/">https://jadewavesenterprise.com/products/bentonite/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Refractory bentonite moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/bentonite/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/rubber-granules/index.html
+++ b/rubber-granules/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Rubber granules page moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Rubber granules moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
-    <meta http-equiv="refresh" content="0; url=/products/" />
-    <script>window.location.replace("/products/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Rubber granules page moved to <a href="/products/">https://jadewavesenterprise.com/products/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Rubber granules moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/salt/index.html
+++ b/salt/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Salt moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Salt moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
-    <meta http-equiv="refresh" content="0; url=/products/salt/" />
-    <script>window.location.replace("/products/salt/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Salt moved to <a href="/products/salt/">https://jadewavesenterprise.com/products/salt/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Salt moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/salt/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -15,45 +15,26 @@ ROOT_FILES = ["index.html", "styles.css", "script.js", "robots.txt", "sitemap.xm
 OPTIONAL_FILES = ["CNAME"]
 SITE_DIRS = [
     "assets",
+    "blog",
     "export-markets",
     "hear-from-ceo",
     "industrial-minerals-exporter-india",
     "operations",
     "privacy-policy",
+    "products",
     "terms-disclaimer",
 ]
-ACTIVE_PRODUCT_DIRS = [
-    "silica-sand",
-    "quartz-sand-for-ceramics",
-    "feldspar",
-    "silica-flour",
-]
-REDIRECT_PRODUCT_DIRS = [
-    "bentonite",
-    "copper-slag",
-    "fly-ash",
-    "kaolin--china-clay",
-    "salt",
-    "talc",
-]
-ACTIVE_BLOG_DIRS = [
-    "quartz-sand-supplier-india-vietnam-buyers-guide",
-    "potassium-vs-sodium-feldspar-import-buyer-guide",
-    "silica-sand-import-checklist-glass-foundry-filtration",
-    "potassium-feldspar-supplier-for-ceramic-tiles",
-    "quartz-powder-supplier-for-engineered-stone",
-    "silica-sand-exporter-from-india",
-    "how-to-check-tds-and-sample-coa-before-mineral-import",
-]
-REDIRECT_BLOG_DIRS = [
-    "bentonite-grade-selection-guide-for-importers",
-    "bentonite-supplier-india",
-    "copper-slag-supplier-for-shipyard-blasting",
-    "fly-ash-exporter-from-india-bulk-shipment",
-    "industrial-salt-exporter",
-    "industrial-salt-import-guide-gulf-buyers",
-    "kaolin-supplier-for-paint-industry",
-]
+EXCLUDED_TOP_LEVEL_DIRS = {
+    ".git",
+    ".github",
+    "_site",
+    "__pycache__",
+    "config",
+    "docs",
+    "reports",
+    "scripts",
+    "tmp",
+}
 
 
 def run_regeneration() -> None:
@@ -70,17 +51,29 @@ def copy_path(source: Path, target: Path) -> None:
         shutil.copy2(source, target)
 
 
+def publishable_root_dirs() -> list[Path]:
+    dirs: list[Path] = []
+    for path in ROOT.iterdir():
+        if not path.is_dir():
+            continue
+        if path.name.startswith(".") or path.name in EXCLUDED_TOP_LEVEL_DIRS:
+            continue
+        if path.name in SITE_DIRS:
+            dirs.append(path)
+            continue
+        if any(child.name == "index.html" for child in path.rglob("index.html")):
+            dirs.append(path)
+    return sorted(dirs, key=lambda item: item.name)
+
+
 def validate_inputs() -> list[str]:
     missing: list[str] = []
-    for name in ROOT_FILES + SITE_DIRS + ["blog/index.html", "products/index.html"]:
+    for name in ROOT_FILES:
         if not (ROOT / name).exists():
             missing.append(name)
-    for name in ACTIVE_BLOG_DIRS + REDIRECT_BLOG_DIRS:
-        if not (ROOT / "blog" / name / "index.html").exists():
-            missing.append(f"blog/{name}/index.html")
-    for name in ACTIVE_PRODUCT_DIRS + REDIRECT_PRODUCT_DIRS:
-        if not (ROOT / "products" / name / "index.html").exists():
-            missing.append(f"products/{name}/index.html")
+    for path in publishable_root_dirs():
+        if not path.exists():
+            missing.append(path.name)
     return missing
 
 
@@ -112,21 +105,16 @@ def build_site() -> None:
         shutil.rmtree(BUILD_DIR)
     BUILD_DIR.mkdir(parents=True, exist_ok=True)
 
-    for name in ROOT_FILES + OPTIONAL_FILES + SITE_DIRS:
+    for name in ROOT_FILES + OPTIONAL_FILES:
         source = ROOT / name
         if source.exists():
             copy_path(source, BUILD_DIR / name)
 
-    copy_path(ROOT / "blog" / "index.html", BUILD_DIR / "blog" / "index.html")
-    for slug in ACTIVE_BLOG_DIRS + REDIRECT_BLOG_DIRS:
-        copy_path(ROOT / "blog" / slug, BUILD_DIR / "blog" / slug)
+    for source in publishable_root_dirs():
+        copy_path(source, BUILD_DIR / source.name)
 
-    copy_path(ROOT / "products" / "index.html", BUILD_DIR / "products" / "index.html")
-    for slug in ACTIVE_PRODUCT_DIRS + REDIRECT_PRODUCT_DIRS:
-        copy_path(ROOT / "products" / slug, BUILD_DIR / "products" / slug)
-
-    expected = [BUILD_DIR / name for name in ROOT_FILES + SITE_DIRS]
-    expected.extend([BUILD_DIR / "blog" / "index.html", BUILD_DIR / "products" / "index.html"])
+    expected = [BUILD_DIR / name for name in ROOT_FILES]
+    expected.extend(BUILD_DIR / path.name for path in publishable_root_dirs())
     expected.extend(sitemap_output_targets())
     missing_outputs = [str(path.relative_to(ROOT)) for path in expected if not path.exists()]
     if missing_outputs:

--- a/silica-flour/index.html
+++ b/silica-flour/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Silica Flour moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Silica flour moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
-    <meta http-equiv="refresh" content="0; url=/products/silica-flour/" />
-    <script>window.location.replace("/products/silica-flour/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Silica Flour moved to <a href="/products/silica-flour/">https://jadewavesenterprise.com/products/silica-flour/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Silica flour moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/silica-flour/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/silica-sand-india/index.html
+++ b/silica-sand-india/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Silica sand page moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Silica sand moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
-    <meta http-equiv="refresh" content="0; url=/products/silica-sand/" />
-    <script>window.location.replace("/products/silica-sand/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Silica sand page moved to <a href="/products/silica-sand/">https://jadewavesenterprise.com/products/silica-sand/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Silica sand moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/silica-sand/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/silica-sand/index.html
+++ b/silica-sand/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Silica Sand moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Silica sand moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
-    <meta http-equiv="refresh" content="0; url=/products/silica-sand/" />
-    <script>window.location.replace("/products/silica-sand/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Silica Sand moved to <a href="/products/silica-sand/">https://jadewavesenterprise.com/products/silica-sand/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Silica sand moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/silica-sand/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/silicasand-supplier-india/index.html
+++ b/silicasand-supplier-india/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Silica sand page moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Silica sand moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
-    <meta http-equiv="refresh" content="0; url=/products/silica-sand/" />
-    <script>window.location.replace("/products/silica-sand/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Silica sand page moved to <a href="/products/silica-sand/">https://jadewavesenterprise.com/products/silica-sand/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Silica sand moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/silica-sand/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -12,11 +12,25 @@
   <url><loc>https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/</loc><lastmod>2026-04-30</lastmod></url>
   <url><loc>https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/</loc><lastmod>2026-04-30</lastmod></url>
   <url><loc>https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/</loc><lastmod>2026-04-30</lastmod></url>
+  <url><loc>https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/</loc><lastmod>2026-04-30</lastmod></url>
+  <url><loc>https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/</loc><lastmod>2026-04-30</lastmod></url>
   <url><loc>https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/</loc><lastmod>2026-04-30</lastmod></url>
+  <url><loc>https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/</loc><lastmod>2026-04-30</lastmod></url>
+  <url><loc>https://jadewavesenterprise.com/blog/bentonite-supplier-india/</loc><lastmod>2026-04-30</lastmod></url>
+  <url><loc>https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/</loc><lastmod>2026-04-30</lastmod></url>
+  <url><loc>https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/</loc><lastmod>2026-04-30</lastmod></url>
+  <url><loc>https://jadewavesenterprise.com/blog/industrial-salt-exporter/</loc><lastmod>2026-04-30</lastmod></url>
   <url><loc>https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/</loc><lastmod>2026-04-30</lastmod></url>
   <url><loc>https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/</loc><lastmod>2026-04-30</lastmod></url>
   <url><loc>https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/</loc><lastmod>2026-04-30</lastmod></url>
   <url><loc>https://jadewavesenterprise.com/products/silica-sand/</loc><lastmod>2026-04-30</lastmod></url>
+  <url><loc>https://jadewavesenterprise.com/products/silica-flour/</loc><lastmod>2026-04-30</lastmod></url>
   <url><loc>https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/</loc><lastmod>2026-04-30</lastmod></url>
+  <url><loc>https://jadewavesenterprise.com/products/bentonite/</loc><lastmod>2026-04-30</lastmod></url>
+  <url><loc>https://jadewavesenterprise.com/products/kaolin--china-clay/</loc><lastmod>2026-04-30</lastmod></url>
+  <url><loc>https://jadewavesenterprise.com/products/talc/</loc><lastmod>2026-04-30</lastmod></url>
   <url><loc>https://jadewavesenterprise.com/products/feldspar/</loc><lastmod>2026-04-30</lastmod></url>
+  <url><loc>https://jadewavesenterprise.com/products/salt/</loc><lastmod>2026-04-30</lastmod></url>
+  <url><loc>https://jadewavesenterprise.com/products/fly-ash/</loc><lastmod>2026-04-30</lastmod></url>
+  <url><loc>https://jadewavesenterprise.com/products/copper-slag/</loc><lastmod>2026-04-30</lastmod></url>
 </urlset>

--- a/talc-/-soapstone/index.html
+++ b/talc-/-soapstone/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Talc page moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Talc moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
-    <meta http-equiv="refresh" content="0; url=/products/talc/" />
-    <script>window.location.replace("/products/talc/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Talc page moved to <a href="/products/talc/">https://jadewavesenterprise.com/products/talc/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Talc moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/talc/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/talc/index.html
+++ b/talc/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Talc moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Talc moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
-    <meta http-equiv="refresh" content="0; url=/products/talc/" />
-    <script>window.location.replace("/products/talc/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Talc moved to <a href="/products/talc/">https://jadewavesenterprise.com/products/talc/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Talc moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/products/talc/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>

--- a/terms-and-conditions/index.html
+++ b/terms-and-conditions/index.html
@@ -3,13 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Terms moved | Jade Waves Enterprise</title>
-    <meta name="robots" content="noindex,follow" />
+    <title>Terms moved</title>
+    <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
+    <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
-    <meta http-equiv="refresh" content="0; url=/terms-disclaimer/" />
-    <script>window.location.replace("/terms-disclaimer/");</script>
+    <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
+    <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <p>Terms moved to <a href="/terms-disclaimer/">https://jadewavesenterprise.com/terms-disclaimer/</a>.</p>
+  <body class="antialiased page-redirect">
+    <main class="shell" style="padding: 6rem 1.5rem;">
+      <p class="section-label">Redirecting</p>
+      <h1>Terms moved</h1>
+      <p>This legacy URL now points to the current Jade Waves page.</p>
+      <p><a href="/terms-disclaimer/">Continue to the current page</a></p>
+    </main>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- publish the full set of current product and buyer-guide pages as real `index,follow` documents again
- restore legacy alias coverage so historical URLs resolve to the current canonical pages instead of falling into dead space
- expand the Pages build to publish alias directories that contain index files
- keep HTTPS enforced and preserve sitemap/build validation

## Validation
- `python3 scripts/build_site.py --regenerate`
- `python3 scripts/seo/daily_runner.py --force`
- verified representative primary pages are `index,follow`
- verified representative legacy alias paths generate redirect documents
