### PR TITLE
Reduce low-value crawl targets

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>About us moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/industrial-minerals-exporter-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/industrial-minerals-exporter-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/industrial-minerals-exporter-india/");</script>

--- a/activated-bleaching-earth/index.html
+++ b/activated-bleaching-earth/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Activated bleaching earth moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/animal-feed-bentonite/index.html
+++ b/animal-feed-bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Animal feed bentonite moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/bentonite-supplier-india/index.html
+++ b/bentonite-supplier-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite supplier article moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-supplier-india/");</script>

--- a/bentonite/index.html
+++ b/bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/blog/bentonite-grade-selection-guide-for-importers/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/blog/bentonite-grade-selection-guide-for-importers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Grade Selection Guide for Drilling, Foundry, and Civil Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/blog/bentonite-supplier-india/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/blog/bentonite-supplier-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Supplier India: What We Offer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-supplier-india/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/blog/copper-slag-supplier-for-shipyard-blasting/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/blog/copper-slag-supplier-for-shipyard-blasting/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag Supplier for Shipyard Blasting: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash Exporter from India Bulk Shipment: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>How to Check TDS and Sample COA Before You Place a Mineral Import Order moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/blog/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/blog/industrial-salt-exporter/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/blog/industrial-salt-exporter/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Exporter: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-exporter/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/blog/industrial-salt-import-guide-gulf-buyers/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/blog/industrial-salt-import-guide-gulf-buyers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Import Guide for UAE, Oman, Qatar, and Kuwait Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/blog/kaolin-supplier-for-paint-industry/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/blog/kaolin-supplier-for-paint-industry/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin Supplier for Paint Industry: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium Feldspar Supplier for Ceramic Tiles: Export-Ready Supply for Manufacturers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium vs Sodium Feldspar: What Import Buyers Should Confirm Before Buying moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/blog/quartz-powder-supplier-for-engineered-stone/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/blog/quartz-powder-supplier-for-engineered-stone/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Powder Supplier for Engineered Stone: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand Supplier from India: Buyer Checklist for Vietnam Ceramics and Glass Teams moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/blog/silica-sand-exporter-from-india/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/blog/silica-sand-exporter-from-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Exporter from India: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Import Checklist for Glass, Foundry, and Filtration Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/export-markets/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/export-markets/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export Markets moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/hear-from-ceo/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/hear-from-ceo/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hear From Ceo moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/hear-from-ceo/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/hear-from-ceo/" />
     <script>window.location.replace("https://jadewavesenterprise.com/hear-from-ceo/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/operations/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/operations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Operations moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/privacy-policy/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/privacy-policy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/privacy-policy/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/privacy-policy/" />
     <script>window.location.replace("https://jadewavesenterprise.com/privacy-policy/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/products/bentonite/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/products/bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/products/copper-slag/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/products/copper-slag/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/products/feldspar/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/products/feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/products/fly-ash/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/products/fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/products/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/products/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Products moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/products/kaolin--china-clay/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/products/kaolin--china-clay/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin (China Clay) moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/products/quartz-sand-for-ceramics/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/products/quartz-sand-for-ceramics/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/products/salt/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/products/salt/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/products/silica-flour/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/products/silica-flour/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Flour moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/products/silica-sand/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/products/silica-sand/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/products/talc/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/products/talc/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/blog/bentonite-grade-selection-guide-for-importers/terms-disclaimer/index.html
+++ b/blog/bentonite-grade-selection-guide-for-importers/terms-disclaimer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms Disclaimer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>

--- a/blog/bentonite-supplier-india/blog/bentonite-grade-selection-guide-for-importers/index.html
+++ b/blog/bentonite-supplier-india/blog/bentonite-grade-selection-guide-for-importers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Grade Selection Guide for Drilling, Foundry, and Civil Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/");</script>

--- a/blog/bentonite-supplier-india/blog/bentonite-supplier-india/index.html
+++ b/blog/bentonite-supplier-india/blog/bentonite-supplier-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Supplier India: What We Offer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-supplier-india/");</script>

--- a/blog/bentonite-supplier-india/blog/copper-slag-supplier-for-shipyard-blasting/index.html
+++ b/blog/bentonite-supplier-india/blog/copper-slag-supplier-for-shipyard-blasting/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag Supplier for Shipyard Blasting: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/");</script>

--- a/blog/bentonite-supplier-india/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
+++ b/blog/bentonite-supplier-india/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash Exporter from India Bulk Shipment: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/");</script>

--- a/blog/bentonite-supplier-india/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
+++ b/blog/bentonite-supplier-india/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>How to Check TDS and Sample COA Before You Place a Mineral Import Order moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/");</script>

--- a/blog/bentonite-supplier-india/blog/index.html
+++ b/blog/bentonite-supplier-india/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/blog/bentonite-supplier-india/blog/industrial-salt-exporter/index.html
+++ b/blog/bentonite-supplier-india/blog/industrial-salt-exporter/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Exporter: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-exporter/");</script>

--- a/blog/bentonite-supplier-india/blog/industrial-salt-import-guide-gulf-buyers/index.html
+++ b/blog/bentonite-supplier-india/blog/industrial-salt-import-guide-gulf-buyers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Import Guide for UAE, Oman, Qatar, and Kuwait Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/");</script>

--- a/blog/bentonite-supplier-india/blog/kaolin-supplier-for-paint-industry/index.html
+++ b/blog/bentonite-supplier-india/blog/kaolin-supplier-for-paint-industry/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin Supplier for Paint Industry: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/");</script>

--- a/blog/bentonite-supplier-india/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
+++ b/blog/bentonite-supplier-india/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium Feldspar Supplier for Ceramic Tiles: Export-Ready Supply for Manufacturers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/");</script>

--- a/blog/bentonite-supplier-india/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
+++ b/blog/bentonite-supplier-india/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium vs Sodium Feldspar: What Import Buyers Should Confirm Before Buying moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/");</script>

--- a/blog/bentonite-supplier-india/blog/quartz-powder-supplier-for-engineered-stone/index.html
+++ b/blog/bentonite-supplier-india/blog/quartz-powder-supplier-for-engineered-stone/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Powder Supplier for Engineered Stone: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/");</script>

--- a/blog/bentonite-supplier-india/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
+++ b/blog/bentonite-supplier-india/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand Supplier from India: Buyer Checklist for Vietnam Ceramics and Glass Teams moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/");</script>

--- a/blog/bentonite-supplier-india/blog/silica-sand-exporter-from-india/index.html
+++ b/blog/bentonite-supplier-india/blog/silica-sand-exporter-from-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Exporter from India: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/");</script>

--- a/blog/bentonite-supplier-india/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
+++ b/blog/bentonite-supplier-india/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Import Checklist for Glass, Foundry, and Filtration Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/");</script>

--- a/blog/bentonite-supplier-india/export-markets/index.html
+++ b/blog/bentonite-supplier-india/export-markets/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export Markets moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/blog/bentonite-supplier-india/hear-from-ceo/index.html
+++ b/blog/bentonite-supplier-india/hear-from-ceo/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hear From Ceo moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/hear-from-ceo/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/hear-from-ceo/" />
     <script>window.location.replace("https://jadewavesenterprise.com/hear-from-ceo/");</script>

--- a/blog/bentonite-supplier-india/operations/index.html
+++ b/blog/bentonite-supplier-india/operations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Operations moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/blog/bentonite-supplier-india/privacy-policy/index.html
+++ b/blog/bentonite-supplier-india/privacy-policy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/privacy-policy/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/privacy-policy/" />
     <script>window.location.replace("https://jadewavesenterprise.com/privacy-policy/");</script>

--- a/blog/bentonite-supplier-india/products/bentonite/index.html
+++ b/blog/bentonite-supplier-india/products/bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/blog/bentonite-supplier-india/products/copper-slag/index.html
+++ b/blog/bentonite-supplier-india/products/copper-slag/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/blog/bentonite-supplier-india/products/feldspar/index.html
+++ b/blog/bentonite-supplier-india/products/feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/blog/bentonite-supplier-india/products/fly-ash/index.html
+++ b/blog/bentonite-supplier-india/products/fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>

--- a/blog/bentonite-supplier-india/products/index.html
+++ b/blog/bentonite-supplier-india/products/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Products moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/blog/bentonite-supplier-india/products/kaolin--china-clay/index.html
+++ b/blog/bentonite-supplier-india/products/kaolin--china-clay/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin (China Clay) moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/blog/bentonite-supplier-india/products/quartz-sand-for-ceramics/index.html
+++ b/blog/bentonite-supplier-india/products/quartz-sand-for-ceramics/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/blog/bentonite-supplier-india/products/salt/index.html
+++ b/blog/bentonite-supplier-india/products/salt/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/blog/bentonite-supplier-india/products/silica-flour/index.html
+++ b/blog/bentonite-supplier-india/products/silica-flour/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Flour moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>

--- a/blog/bentonite-supplier-india/products/silica-sand/index.html
+++ b/blog/bentonite-supplier-india/products/silica-sand/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/blog/bentonite-supplier-india/products/talc/index.html
+++ b/blog/bentonite-supplier-india/products/talc/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/blog/bentonite-supplier-india/terms-disclaimer/index.html
+++ b/blog/bentonite-supplier-india/terms-disclaimer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms Disclaimer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>

--- a/blog/blog/bentonite-grade-selection-guide-for-importers/index.html
+++ b/blog/blog/bentonite-grade-selection-guide-for-importers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Grade Selection Guide for Drilling, Foundry, and Civil Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/");</script>

--- a/blog/blog/bentonite-supplier-india/index.html
+++ b/blog/blog/bentonite-supplier-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Supplier India: What We Offer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-supplier-india/");</script>

--- a/blog/blog/copper-slag-supplier-for-shipyard-blasting/index.html
+++ b/blog/blog/copper-slag-supplier-for-shipyard-blasting/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag Supplier for Shipyard Blasting: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/");</script>

--- a/blog/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
+++ b/blog/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash Exporter from India Bulk Shipment: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/");</script>

--- a/blog/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
+++ b/blog/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>How to Check TDS and Sample COA Before You Place a Mineral Import Order moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/");</script>

--- a/blog/blog/index.html
+++ b/blog/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/blog/blog/industrial-salt-exporter/index.html
+++ b/blog/blog/industrial-salt-exporter/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Exporter: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-exporter/");</script>

--- a/blog/blog/industrial-salt-import-guide-gulf-buyers/index.html
+++ b/blog/blog/industrial-salt-import-guide-gulf-buyers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Import Guide for UAE, Oman, Qatar, and Kuwait Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/");</script>

--- a/blog/blog/kaolin-supplier-for-paint-industry/index.html
+++ b/blog/blog/kaolin-supplier-for-paint-industry/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin Supplier for Paint Industry: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/");</script>

--- a/blog/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
+++ b/blog/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium Feldspar Supplier for Ceramic Tiles: Export-Ready Supply for Manufacturers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/");</script>

--- a/blog/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
+++ b/blog/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium vs Sodium Feldspar: What Import Buyers Should Confirm Before Buying moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/");</script>

--- a/blog/blog/quartz-powder-supplier-for-engineered-stone/index.html
+++ b/blog/blog/quartz-powder-supplier-for-engineered-stone/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Powder Supplier for Engineered Stone: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/");</script>

--- a/blog/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
+++ b/blog/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand Supplier from India: Buyer Checklist for Vietnam Ceramics and Glass Teams moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/");</script>

--- a/blog/blog/silica-sand-exporter-from-india/index.html
+++ b/blog/blog/silica-sand-exporter-from-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Exporter from India: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/");</script>

--- a/blog/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
+++ b/blog/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Import Checklist for Glass, Foundry, and Filtration Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/blog/bentonite-grade-selection-guide-for-importers/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/blog/bentonite-grade-selection-guide-for-importers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Grade Selection Guide for Drilling, Foundry, and Civil Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/blog/bentonite-supplier-india/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/blog/bentonite-supplier-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Supplier India: What We Offer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-supplier-india/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/blog/copper-slag-supplier-for-shipyard-blasting/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/blog/copper-slag-supplier-for-shipyard-blasting/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag Supplier for Shipyard Blasting: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash Exporter from India Bulk Shipment: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>How to Check TDS and Sample COA Before You Place a Mineral Import Order moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/blog/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/blog/industrial-salt-exporter/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/blog/industrial-salt-exporter/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Exporter: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-exporter/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/blog/industrial-salt-import-guide-gulf-buyers/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/blog/industrial-salt-import-guide-gulf-buyers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Import Guide for UAE, Oman, Qatar, and Kuwait Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/blog/kaolin-supplier-for-paint-industry/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/blog/kaolin-supplier-for-paint-industry/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin Supplier for Paint Industry: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium Feldspar Supplier for Ceramic Tiles: Export-Ready Supply for Manufacturers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium vs Sodium Feldspar: What Import Buyers Should Confirm Before Buying moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/blog/quartz-powder-supplier-for-engineered-stone/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/blog/quartz-powder-supplier-for-engineered-stone/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Powder Supplier for Engineered Stone: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand Supplier from India: Buyer Checklist for Vietnam Ceramics and Glass Teams moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/blog/silica-sand-exporter-from-india/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/blog/silica-sand-exporter-from-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Exporter from India: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Import Checklist for Glass, Foundry, and Filtration Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/export-markets/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/export-markets/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export Markets moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/hear-from-ceo/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/hear-from-ceo/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hear From Ceo moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/hear-from-ceo/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/hear-from-ceo/" />
     <script>window.location.replace("https://jadewavesenterprise.com/hear-from-ceo/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/operations/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/operations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Operations moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/privacy-policy/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/privacy-policy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/privacy-policy/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/privacy-policy/" />
     <script>window.location.replace("https://jadewavesenterprise.com/privacy-policy/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/products/bentonite/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/products/bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/products/copper-slag/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/products/copper-slag/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/products/feldspar/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/products/feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/products/fly-ash/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/products/fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/products/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/products/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Products moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/products/kaolin--china-clay/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/products/kaolin--china-clay/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin (China Clay) moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/products/quartz-sand-for-ceramics/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/products/quartz-sand-for-ceramics/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/products/salt/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/products/salt/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/products/silica-flour/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/products/silica-flour/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Flour moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/products/silica-sand/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/products/silica-sand/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/products/talc/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/products/talc/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/blog/copper-slag-supplier-for-shipyard-blasting/terms-disclaimer/index.html
+++ b/blog/copper-slag-supplier-for-shipyard-blasting/terms-disclaimer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms Disclaimer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>

--- a/blog/export-markets/index.html
+++ b/blog/export-markets/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Markets moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/blog/bentonite-grade-selection-guide-for-importers/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/blog/bentonite-grade-selection-guide-for-importers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Grade Selection Guide for Drilling, Foundry, and Civil Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/blog/bentonite-supplier-india/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/blog/bentonite-supplier-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Supplier India: What We Offer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-supplier-india/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/blog/copper-slag-supplier-for-shipyard-blasting/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/blog/copper-slag-supplier-for-shipyard-blasting/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag Supplier for Shipyard Blasting: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash Exporter from India Bulk Shipment: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>How to Check TDS and Sample COA Before You Place a Mineral Import Order moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/blog/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/blog/industrial-salt-exporter/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/blog/industrial-salt-exporter/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Exporter: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-exporter/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/blog/industrial-salt-import-guide-gulf-buyers/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/blog/industrial-salt-import-guide-gulf-buyers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Import Guide for UAE, Oman, Qatar, and Kuwait Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/blog/kaolin-supplier-for-paint-industry/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/blog/kaolin-supplier-for-paint-industry/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin Supplier for Paint Industry: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium Feldspar Supplier for Ceramic Tiles: Export-Ready Supply for Manufacturers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium vs Sodium Feldspar: What Import Buyers Should Confirm Before Buying moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/blog/quartz-powder-supplier-for-engineered-stone/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/blog/quartz-powder-supplier-for-engineered-stone/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Powder Supplier for Engineered Stone: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand Supplier from India: Buyer Checklist for Vietnam Ceramics and Glass Teams moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/blog/silica-sand-exporter-from-india/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/blog/silica-sand-exporter-from-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Exporter from India: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Import Checklist for Glass, Foundry, and Filtration Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/export-markets/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/export-markets/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export Markets moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/hear-from-ceo/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/hear-from-ceo/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hear From Ceo moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/hear-from-ceo/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/hear-from-ceo/" />
     <script>window.location.replace("https://jadewavesenterprise.com/hear-from-ceo/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/operations/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/operations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Operations moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/privacy-policy/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/privacy-policy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/privacy-policy/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/privacy-policy/" />
     <script>window.location.replace("https://jadewavesenterprise.com/privacy-policy/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/products/bentonite/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/products/bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/products/copper-slag/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/products/copper-slag/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/products/feldspar/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/products/feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/products/fly-ash/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/products/fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/products/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/products/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Products moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/products/kaolin--china-clay/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/products/kaolin--china-clay/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin (China Clay) moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/products/quartz-sand-for-ceramics/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/products/quartz-sand-for-ceramics/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/products/salt/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/products/salt/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/products/silica-flour/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/products/silica-flour/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Flour moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/products/silica-sand/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/products/silica-sand/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/products/talc/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/products/talc/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/blog/fly-ash-exporter-from-india-bulk-shipment/terms-disclaimer/index.html
+++ b/blog/fly-ash-exporter-from-india-bulk-shipment/terms-disclaimer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms Disclaimer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/bentonite-grade-selection-guide-for-importers/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/bentonite-grade-selection-guide-for-importers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Grade Selection Guide for Drilling, Foundry, and Civil Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/bentonite-supplier-india/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/bentonite-supplier-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Supplier India: What We Offer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-supplier-india/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/copper-slag-supplier-for-shipyard-blasting/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/copper-slag-supplier-for-shipyard-blasting/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag Supplier for Shipyard Blasting: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash Exporter from India Bulk Shipment: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>How to Check TDS and Sample COA Before You Place a Mineral Import Order moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/industrial-salt-exporter/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/industrial-salt-exporter/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Exporter: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-exporter/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/industrial-salt-import-guide-gulf-buyers/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/industrial-salt-import-guide-gulf-buyers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Import Guide for UAE, Oman, Qatar, and Kuwait Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/kaolin-supplier-for-paint-industry/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/kaolin-supplier-for-paint-industry/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin Supplier for Paint Industry: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium Feldspar Supplier for Ceramic Tiles: Export-Ready Supply for Manufacturers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium vs Sodium Feldspar: What Import Buyers Should Confirm Before Buying moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/quartz-powder-supplier-for-engineered-stone/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/quartz-powder-supplier-for-engineered-stone/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Powder Supplier for Engineered Stone: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand Supplier from India: Buyer Checklist for Vietnam Ceramics and Glass Teams moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/silica-sand-exporter-from-india/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/silica-sand-exporter-from-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Exporter from India: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Import Checklist for Glass, Foundry, and Filtration Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/export-markets/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/export-markets/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export Markets moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/hear-from-ceo/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/hear-from-ceo/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hear From Ceo moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/hear-from-ceo/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/hear-from-ceo/" />
     <script>window.location.replace("https://jadewavesenterprise.com/hear-from-ceo/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/operations/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/operations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Operations moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/privacy-policy/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/privacy-policy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/privacy-policy/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/privacy-policy/" />
     <script>window.location.replace("https://jadewavesenterprise.com/privacy-policy/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/products/bentonite/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/products/bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/products/copper-slag/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/products/copper-slag/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/products/feldspar/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/products/feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/products/fly-ash/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/products/fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/products/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/products/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Products moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/products/kaolin--china-clay/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/products/kaolin--china-clay/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin (China Clay) moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/products/quartz-sand-for-ceramics/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/products/quartz-sand-for-ceramics/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/products/salt/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/products/salt/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/products/silica-flour/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/products/silica-flour/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Flour moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/products/silica-sand/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/products/silica-sand/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/products/talc/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/products/talc/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/blog/how-to-check-tds-and-sample-coa-before-mineral-import/terms-disclaimer/index.html
+++ b/blog/how-to-check-tds-and-sample-coa-before-mineral-import/terms-disclaimer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms Disclaimer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>

--- a/blog/industrial-salt-exporter/blog/bentonite-grade-selection-guide-for-importers/index.html
+++ b/blog/industrial-salt-exporter/blog/bentonite-grade-selection-guide-for-importers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Grade Selection Guide for Drilling, Foundry, and Civil Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/");</script>

--- a/blog/industrial-salt-exporter/blog/bentonite-supplier-india/index.html
+++ b/blog/industrial-salt-exporter/blog/bentonite-supplier-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Supplier India: What We Offer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-supplier-india/");</script>

--- a/blog/industrial-salt-exporter/blog/copper-slag-supplier-for-shipyard-blasting/index.html
+++ b/blog/industrial-salt-exporter/blog/copper-slag-supplier-for-shipyard-blasting/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag Supplier for Shipyard Blasting: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/");</script>

--- a/blog/industrial-salt-exporter/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
+++ b/blog/industrial-salt-exporter/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash Exporter from India Bulk Shipment: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/");</script>

--- a/blog/industrial-salt-exporter/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
+++ b/blog/industrial-salt-exporter/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>How to Check TDS and Sample COA Before You Place a Mineral Import Order moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/");</script>

--- a/blog/industrial-salt-exporter/blog/index.html
+++ b/blog/industrial-salt-exporter/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/blog/industrial-salt-exporter/blog/industrial-salt-exporter/index.html
+++ b/blog/industrial-salt-exporter/blog/industrial-salt-exporter/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Exporter: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-exporter/");</script>

--- a/blog/industrial-salt-exporter/blog/industrial-salt-import-guide-gulf-buyers/index.html
+++ b/blog/industrial-salt-exporter/blog/industrial-salt-import-guide-gulf-buyers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Import Guide for UAE, Oman, Qatar, and Kuwait Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/");</script>

--- a/blog/industrial-salt-exporter/blog/kaolin-supplier-for-paint-industry/index.html
+++ b/blog/industrial-salt-exporter/blog/kaolin-supplier-for-paint-industry/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin Supplier for Paint Industry: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/");</script>

--- a/blog/industrial-salt-exporter/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
+++ b/blog/industrial-salt-exporter/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium Feldspar Supplier for Ceramic Tiles: Export-Ready Supply for Manufacturers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/");</script>

--- a/blog/industrial-salt-exporter/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
+++ b/blog/industrial-salt-exporter/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium vs Sodium Feldspar: What Import Buyers Should Confirm Before Buying moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/");</script>

--- a/blog/industrial-salt-exporter/blog/quartz-powder-supplier-for-engineered-stone/index.html
+++ b/blog/industrial-salt-exporter/blog/quartz-powder-supplier-for-engineered-stone/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Powder Supplier for Engineered Stone: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/");</script>

--- a/blog/industrial-salt-exporter/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
+++ b/blog/industrial-salt-exporter/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand Supplier from India: Buyer Checklist for Vietnam Ceramics and Glass Teams moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/");</script>

--- a/blog/industrial-salt-exporter/blog/silica-sand-exporter-from-india/index.html
+++ b/blog/industrial-salt-exporter/blog/silica-sand-exporter-from-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Exporter from India: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/");</script>

--- a/blog/industrial-salt-exporter/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
+++ b/blog/industrial-salt-exporter/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Import Checklist for Glass, Foundry, and Filtration Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/");</script>

--- a/blog/industrial-salt-exporter/export-markets/index.html
+++ b/blog/industrial-salt-exporter/export-markets/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export Markets moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/blog/industrial-salt-exporter/hear-from-ceo/index.html
+++ b/blog/industrial-salt-exporter/hear-from-ceo/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hear From Ceo moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/hear-from-ceo/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/hear-from-ceo/" />
     <script>window.location.replace("https://jadewavesenterprise.com/hear-from-ceo/");</script>

--- a/blog/industrial-salt-exporter/operations/index.html
+++ b/blog/industrial-salt-exporter/operations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Operations moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/blog/industrial-salt-exporter/privacy-policy/index.html
+++ b/blog/industrial-salt-exporter/privacy-policy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/privacy-policy/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/privacy-policy/" />
     <script>window.location.replace("https://jadewavesenterprise.com/privacy-policy/");</script>

--- a/blog/industrial-salt-exporter/products/bentonite/index.html
+++ b/blog/industrial-salt-exporter/products/bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/blog/industrial-salt-exporter/products/copper-slag/index.html
+++ b/blog/industrial-salt-exporter/products/copper-slag/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/blog/industrial-salt-exporter/products/feldspar/index.html
+++ b/blog/industrial-salt-exporter/products/feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/blog/industrial-salt-exporter/products/fly-ash/index.html
+++ b/blog/industrial-salt-exporter/products/fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>

--- a/blog/industrial-salt-exporter/products/index.html
+++ b/blog/industrial-salt-exporter/products/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Products moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/blog/industrial-salt-exporter/products/kaolin--china-clay/index.html
+++ b/blog/industrial-salt-exporter/products/kaolin--china-clay/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin (China Clay) moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/blog/industrial-salt-exporter/products/quartz-sand-for-ceramics/index.html
+++ b/blog/industrial-salt-exporter/products/quartz-sand-for-ceramics/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/blog/industrial-salt-exporter/products/salt/index.html
+++ b/blog/industrial-salt-exporter/products/salt/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/blog/industrial-salt-exporter/products/silica-flour/index.html
+++ b/blog/industrial-salt-exporter/products/silica-flour/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Flour moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>

--- a/blog/industrial-salt-exporter/products/silica-sand/index.html
+++ b/blog/industrial-salt-exporter/products/silica-sand/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/blog/industrial-salt-exporter/products/talc/index.html
+++ b/blog/industrial-salt-exporter/products/talc/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/blog/industrial-salt-exporter/terms-disclaimer/index.html
+++ b/blog/industrial-salt-exporter/terms-disclaimer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms Disclaimer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/blog/bentonite-grade-selection-guide-for-importers/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/blog/bentonite-grade-selection-guide-for-importers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Grade Selection Guide for Drilling, Foundry, and Civil Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/blog/bentonite-supplier-india/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/blog/bentonite-supplier-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Supplier India: What We Offer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-supplier-india/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/blog/copper-slag-supplier-for-shipyard-blasting/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/blog/copper-slag-supplier-for-shipyard-blasting/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag Supplier for Shipyard Blasting: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash Exporter from India Bulk Shipment: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>How to Check TDS and Sample COA Before You Place a Mineral Import Order moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/blog/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/blog/industrial-salt-exporter/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/blog/industrial-salt-exporter/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Exporter: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-exporter/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/blog/industrial-salt-import-guide-gulf-buyers/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/blog/industrial-salt-import-guide-gulf-buyers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Import Guide for UAE, Oman, Qatar, and Kuwait Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/blog/kaolin-supplier-for-paint-industry/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/blog/kaolin-supplier-for-paint-industry/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin Supplier for Paint Industry: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium Feldspar Supplier for Ceramic Tiles: Export-Ready Supply for Manufacturers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium vs Sodium Feldspar: What Import Buyers Should Confirm Before Buying moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/blog/quartz-powder-supplier-for-engineered-stone/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/blog/quartz-powder-supplier-for-engineered-stone/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Powder Supplier for Engineered Stone: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand Supplier from India: Buyer Checklist for Vietnam Ceramics and Glass Teams moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/blog/silica-sand-exporter-from-india/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/blog/silica-sand-exporter-from-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Exporter from India: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Import Checklist for Glass, Foundry, and Filtration Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/export-markets/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/export-markets/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export Markets moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/hear-from-ceo/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/hear-from-ceo/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hear From Ceo moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/hear-from-ceo/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/hear-from-ceo/" />
     <script>window.location.replace("https://jadewavesenterprise.com/hear-from-ceo/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/operations/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/operations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Operations moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/privacy-policy/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/privacy-policy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/privacy-policy/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/privacy-policy/" />
     <script>window.location.replace("https://jadewavesenterprise.com/privacy-policy/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/products/bentonite/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/products/bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/products/copper-slag/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/products/copper-slag/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/products/feldspar/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/products/feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/products/fly-ash/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/products/fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/products/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/products/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Products moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/products/kaolin--china-clay/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/products/kaolin--china-clay/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin (China Clay) moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/products/quartz-sand-for-ceramics/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/products/quartz-sand-for-ceramics/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/products/salt/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/products/salt/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/products/silica-flour/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/products/silica-flour/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Flour moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/products/silica-sand/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/products/silica-sand/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/products/talc/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/products/talc/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/blog/industrial-salt-import-guide-gulf-buyers/terms-disclaimer/index.html
+++ b/blog/industrial-salt-import-guide-gulf-buyers/terms-disclaimer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms Disclaimer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/blog/bentonite-grade-selection-guide-for-importers/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/blog/bentonite-grade-selection-guide-for-importers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Grade Selection Guide for Drilling, Foundry, and Civil Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/blog/bentonite-supplier-india/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/blog/bentonite-supplier-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Supplier India: What We Offer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-supplier-india/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/blog/copper-slag-supplier-for-shipyard-blasting/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/blog/copper-slag-supplier-for-shipyard-blasting/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag Supplier for Shipyard Blasting: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash Exporter from India Bulk Shipment: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>How to Check TDS and Sample COA Before You Place a Mineral Import Order moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/blog/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/blog/industrial-salt-exporter/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/blog/industrial-salt-exporter/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Exporter: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-exporter/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/blog/industrial-salt-import-guide-gulf-buyers/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/blog/industrial-salt-import-guide-gulf-buyers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Import Guide for UAE, Oman, Qatar, and Kuwait Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/blog/kaolin-supplier-for-paint-industry/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/blog/kaolin-supplier-for-paint-industry/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin Supplier for Paint Industry: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium Feldspar Supplier for Ceramic Tiles: Export-Ready Supply for Manufacturers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium vs Sodium Feldspar: What Import Buyers Should Confirm Before Buying moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/blog/quartz-powder-supplier-for-engineered-stone/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/blog/quartz-powder-supplier-for-engineered-stone/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Powder Supplier for Engineered Stone: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand Supplier from India: Buyer Checklist for Vietnam Ceramics and Glass Teams moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/blog/silica-sand-exporter-from-india/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/blog/silica-sand-exporter-from-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Exporter from India: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Import Checklist for Glass, Foundry, and Filtration Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/export-markets/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/export-markets/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export Markets moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/hear-from-ceo/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/hear-from-ceo/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hear From Ceo moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/hear-from-ceo/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/hear-from-ceo/" />
     <script>window.location.replace("https://jadewavesenterprise.com/hear-from-ceo/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/operations/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/operations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Operations moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/privacy-policy/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/privacy-policy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/privacy-policy/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/privacy-policy/" />
     <script>window.location.replace("https://jadewavesenterprise.com/privacy-policy/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/products/bentonite/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/products/bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/products/copper-slag/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/products/copper-slag/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/products/feldspar/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/products/feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/products/fly-ash/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/products/fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/products/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/products/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Products moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/products/kaolin--china-clay/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/products/kaolin--china-clay/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin (China Clay) moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/products/quartz-sand-for-ceramics/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/products/quartz-sand-for-ceramics/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/products/salt/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/products/salt/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/products/silica-flour/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/products/silica-flour/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Flour moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/products/silica-sand/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/products/silica-sand/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/products/talc/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/products/talc/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/blog/kaolin-supplier-for-paint-industry/terms-disclaimer/index.html
+++ b/blog/kaolin-supplier-for-paint-industry/terms-disclaimer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms Disclaimer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>

--- a/blog/operations/index.html
+++ b/blog/operations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Operations moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/bentonite-grade-selection-guide-for-importers/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/bentonite-grade-selection-guide-for-importers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Grade Selection Guide for Drilling, Foundry, and Civil Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/bentonite-supplier-india/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/bentonite-supplier-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Supplier India: What We Offer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-supplier-india/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/copper-slag-supplier-for-shipyard-blasting/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/copper-slag-supplier-for-shipyard-blasting/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag Supplier for Shipyard Blasting: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash Exporter from India Bulk Shipment: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>How to Check TDS and Sample COA Before You Place a Mineral Import Order moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/industrial-salt-exporter/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/industrial-salt-exporter/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Exporter: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-exporter/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/industrial-salt-import-guide-gulf-buyers/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/industrial-salt-import-guide-gulf-buyers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Import Guide for UAE, Oman, Qatar, and Kuwait Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/kaolin-supplier-for-paint-industry/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/kaolin-supplier-for-paint-industry/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin Supplier for Paint Industry: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium Feldspar Supplier for Ceramic Tiles: Export-Ready Supply for Manufacturers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium vs Sodium Feldspar: What Import Buyers Should Confirm Before Buying moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/quartz-powder-supplier-for-engineered-stone/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/quartz-powder-supplier-for-engineered-stone/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Powder Supplier for Engineered Stone: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand Supplier from India: Buyer Checklist for Vietnam Ceramics and Glass Teams moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/silica-sand-exporter-from-india/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/silica-sand-exporter-from-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Exporter from India: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Import Checklist for Glass, Foundry, and Filtration Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/export-markets/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/export-markets/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export Markets moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/hear-from-ceo/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/hear-from-ceo/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hear From Ceo moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/hear-from-ceo/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/hear-from-ceo/" />
     <script>window.location.replace("https://jadewavesenterprise.com/hear-from-ceo/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/operations/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/operations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Operations moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/privacy-policy/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/privacy-policy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/privacy-policy/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/privacy-policy/" />
     <script>window.location.replace("https://jadewavesenterprise.com/privacy-policy/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/products/bentonite/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/products/bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/products/copper-slag/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/products/copper-slag/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/products/feldspar/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/products/feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/products/fly-ash/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/products/fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/products/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/products/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Products moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/products/kaolin--china-clay/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/products/kaolin--china-clay/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin (China Clay) moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/products/quartz-sand-for-ceramics/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/products/quartz-sand-for-ceramics/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/products/salt/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/products/salt/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/products/silica-flour/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/products/silica-flour/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Flour moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/products/silica-sand/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/products/silica-sand/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/products/talc/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/products/talc/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/blog/potassium-feldspar-supplier-for-ceramic-tiles/terms-disclaimer/index.html
+++ b/blog/potassium-feldspar-supplier-for-ceramic-tiles/terms-disclaimer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms Disclaimer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/bentonite-grade-selection-guide-for-importers/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/bentonite-grade-selection-guide-for-importers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Grade Selection Guide for Drilling, Foundry, and Civil Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/bentonite-supplier-india/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/bentonite-supplier-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Supplier India: What We Offer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-supplier-india/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/copper-slag-supplier-for-shipyard-blasting/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/copper-slag-supplier-for-shipyard-blasting/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag Supplier for Shipyard Blasting: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash Exporter from India Bulk Shipment: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>How to Check TDS and Sample COA Before You Place a Mineral Import Order moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/industrial-salt-exporter/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/industrial-salt-exporter/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Exporter: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-exporter/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/industrial-salt-import-guide-gulf-buyers/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/industrial-salt-import-guide-gulf-buyers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Import Guide for UAE, Oman, Qatar, and Kuwait Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/kaolin-supplier-for-paint-industry/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/kaolin-supplier-for-paint-industry/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin Supplier for Paint Industry: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium Feldspar Supplier for Ceramic Tiles: Export-Ready Supply for Manufacturers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium vs Sodium Feldspar: What Import Buyers Should Confirm Before Buying moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/quartz-powder-supplier-for-engineered-stone/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/quartz-powder-supplier-for-engineered-stone/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Powder Supplier for Engineered Stone: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand Supplier from India: Buyer Checklist for Vietnam Ceramics and Glass Teams moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/silica-sand-exporter-from-india/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/silica-sand-exporter-from-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Exporter from India: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Import Checklist for Glass, Foundry, and Filtration Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/export-markets/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/export-markets/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export Markets moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/hear-from-ceo/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/hear-from-ceo/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hear From Ceo moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/hear-from-ceo/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/hear-from-ceo/" />
     <script>window.location.replace("https://jadewavesenterprise.com/hear-from-ceo/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/operations/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/operations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Operations moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/privacy-policy/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/privacy-policy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/privacy-policy/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/privacy-policy/" />
     <script>window.location.replace("https://jadewavesenterprise.com/privacy-policy/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/products/bentonite/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/products/bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/products/copper-slag/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/products/copper-slag/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/products/feldspar/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/products/feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/products/fly-ash/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/products/fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/products/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/products/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Products moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/products/kaolin--china-clay/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/products/kaolin--china-clay/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin (China Clay) moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/products/quartz-sand-for-ceramics/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/products/quartz-sand-for-ceramics/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/products/salt/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/products/salt/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/products/silica-flour/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/products/silica-flour/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Flour moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/products/silica-sand/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/products/silica-sand/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/products/talc/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/products/talc/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/blog/potassium-vs-sodium-feldspar-import-buyer-guide/terms-disclaimer/index.html
+++ b/blog/potassium-vs-sodium-feldspar-import-buyer-guide/terms-disclaimer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms Disclaimer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>

--- a/blog/products/index.html
+++ b/blog/products/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Products moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/blog/bentonite-grade-selection-guide-for-importers/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/blog/bentonite-grade-selection-guide-for-importers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Grade Selection Guide for Drilling, Foundry, and Civil Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/blog/bentonite-supplier-india/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/blog/bentonite-supplier-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Supplier India: What We Offer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-supplier-india/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/blog/copper-slag-supplier-for-shipyard-blasting/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/blog/copper-slag-supplier-for-shipyard-blasting/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag Supplier for Shipyard Blasting: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash Exporter from India Bulk Shipment: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>How to Check TDS and Sample COA Before You Place a Mineral Import Order moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/blog/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/blog/industrial-salt-exporter/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/blog/industrial-salt-exporter/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Exporter: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-exporter/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/blog/industrial-salt-import-guide-gulf-buyers/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/blog/industrial-salt-import-guide-gulf-buyers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Import Guide for UAE, Oman, Qatar, and Kuwait Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/blog/kaolin-supplier-for-paint-industry/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/blog/kaolin-supplier-for-paint-industry/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin Supplier for Paint Industry: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium Feldspar Supplier for Ceramic Tiles: Export-Ready Supply for Manufacturers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium vs Sodium Feldspar: What Import Buyers Should Confirm Before Buying moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/blog/quartz-powder-supplier-for-engineered-stone/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/blog/quartz-powder-supplier-for-engineered-stone/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Powder Supplier for Engineered Stone: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand Supplier from India: Buyer Checklist for Vietnam Ceramics and Glass Teams moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/blog/silica-sand-exporter-from-india/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/blog/silica-sand-exporter-from-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Exporter from India: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Import Checklist for Glass, Foundry, and Filtration Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/export-markets/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/export-markets/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export Markets moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/hear-from-ceo/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/hear-from-ceo/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hear From Ceo moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/hear-from-ceo/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/hear-from-ceo/" />
     <script>window.location.replace("https://jadewavesenterprise.com/hear-from-ceo/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/operations/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/operations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Operations moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/privacy-policy/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/privacy-policy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/privacy-policy/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/privacy-policy/" />
     <script>window.location.replace("https://jadewavesenterprise.com/privacy-policy/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/products/bentonite/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/products/bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/products/copper-slag/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/products/copper-slag/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/products/feldspar/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/products/feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/products/fly-ash/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/products/fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/products/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/products/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Products moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/products/kaolin--china-clay/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/products/kaolin--china-clay/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin (China Clay) moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/products/quartz-sand-for-ceramics/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/products/quartz-sand-for-ceramics/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/products/salt/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/products/salt/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/products/silica-flour/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/products/silica-flour/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Flour moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/products/silica-sand/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/products/silica-sand/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/products/talc/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/products/talc/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/blog/quartz-powder-supplier-for-engineered-stone/terms-disclaimer/index.html
+++ b/blog/quartz-powder-supplier-for-engineered-stone/terms-disclaimer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms Disclaimer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/bentonite-grade-selection-guide-for-importers/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/bentonite-grade-selection-guide-for-importers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Grade Selection Guide for Drilling, Foundry, and Civil Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/bentonite-supplier-india/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/bentonite-supplier-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Supplier India: What We Offer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-supplier-india/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/copper-slag-supplier-for-shipyard-blasting/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/copper-slag-supplier-for-shipyard-blasting/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag Supplier for Shipyard Blasting: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash Exporter from India Bulk Shipment: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>How to Check TDS and Sample COA Before You Place a Mineral Import Order moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/industrial-salt-exporter/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/industrial-salt-exporter/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Exporter: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-exporter/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/industrial-salt-import-guide-gulf-buyers/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/industrial-salt-import-guide-gulf-buyers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Import Guide for UAE, Oman, Qatar, and Kuwait Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/kaolin-supplier-for-paint-industry/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/kaolin-supplier-for-paint-industry/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin Supplier for Paint Industry: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium Feldspar Supplier for Ceramic Tiles: Export-Ready Supply for Manufacturers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium vs Sodium Feldspar: What Import Buyers Should Confirm Before Buying moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/quartz-powder-supplier-for-engineered-stone/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/quartz-powder-supplier-for-engineered-stone/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Powder Supplier for Engineered Stone: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand Supplier from India: Buyer Checklist for Vietnam Ceramics and Glass Teams moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/silica-sand-exporter-from-india/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/silica-sand-exporter-from-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Exporter from India: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Import Checklist for Glass, Foundry, and Filtration Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/export-markets/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/export-markets/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export Markets moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/hear-from-ceo/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/hear-from-ceo/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hear From Ceo moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/hear-from-ceo/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/hear-from-ceo/" />
     <script>window.location.replace("https://jadewavesenterprise.com/hear-from-ceo/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/operations/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/operations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Operations moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/privacy-policy/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/privacy-policy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/privacy-policy/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/privacy-policy/" />
     <script>window.location.replace("https://jadewavesenterprise.com/privacy-policy/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/products/bentonite/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/products/bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/products/copper-slag/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/products/copper-slag/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/products/feldspar/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/products/feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/products/fly-ash/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/products/fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/products/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/products/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Products moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/products/kaolin--china-clay/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/products/kaolin--china-clay/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin (China Clay) moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/products/quartz-sand-for-ceramics/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/products/quartz-sand-for-ceramics/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/products/salt/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/products/salt/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/products/silica-flour/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/products/silica-flour/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Flour moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/products/silica-sand/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/products/silica-sand/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/products/talc/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/products/talc/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/blog/quartz-sand-supplier-india-vietnam-buyers-guide/terms-disclaimer/index.html
+++ b/blog/quartz-sand-supplier-india-vietnam-buyers-guide/terms-disclaimer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms Disclaimer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>

--- a/blog/silica-sand-exporter-from-india/blog/bentonite-grade-selection-guide-for-importers/index.html
+++ b/blog/silica-sand-exporter-from-india/blog/bentonite-grade-selection-guide-for-importers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Grade Selection Guide for Drilling, Foundry, and Civil Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/");</script>

--- a/blog/silica-sand-exporter-from-india/blog/bentonite-supplier-india/index.html
+++ b/blog/silica-sand-exporter-from-india/blog/bentonite-supplier-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Supplier India: What We Offer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-supplier-india/");</script>

--- a/blog/silica-sand-exporter-from-india/blog/copper-slag-supplier-for-shipyard-blasting/index.html
+++ b/blog/silica-sand-exporter-from-india/blog/copper-slag-supplier-for-shipyard-blasting/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag Supplier for Shipyard Blasting: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/");</script>

--- a/blog/silica-sand-exporter-from-india/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
+++ b/blog/silica-sand-exporter-from-india/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash Exporter from India Bulk Shipment: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/");</script>

--- a/blog/silica-sand-exporter-from-india/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
+++ b/blog/silica-sand-exporter-from-india/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>How to Check TDS and Sample COA Before You Place a Mineral Import Order moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/");</script>

--- a/blog/silica-sand-exporter-from-india/blog/index.html
+++ b/blog/silica-sand-exporter-from-india/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/blog/silica-sand-exporter-from-india/blog/industrial-salt-exporter/index.html
+++ b/blog/silica-sand-exporter-from-india/blog/industrial-salt-exporter/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Exporter: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-exporter/");</script>

--- a/blog/silica-sand-exporter-from-india/blog/industrial-salt-import-guide-gulf-buyers/index.html
+++ b/blog/silica-sand-exporter-from-india/blog/industrial-salt-import-guide-gulf-buyers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Import Guide for UAE, Oman, Qatar, and Kuwait Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/");</script>

--- a/blog/silica-sand-exporter-from-india/blog/kaolin-supplier-for-paint-industry/index.html
+++ b/blog/silica-sand-exporter-from-india/blog/kaolin-supplier-for-paint-industry/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin Supplier for Paint Industry: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/");</script>

--- a/blog/silica-sand-exporter-from-india/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
+++ b/blog/silica-sand-exporter-from-india/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium Feldspar Supplier for Ceramic Tiles: Export-Ready Supply for Manufacturers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/");</script>

--- a/blog/silica-sand-exporter-from-india/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
+++ b/blog/silica-sand-exporter-from-india/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium vs Sodium Feldspar: What Import Buyers Should Confirm Before Buying moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/");</script>

--- a/blog/silica-sand-exporter-from-india/blog/quartz-powder-supplier-for-engineered-stone/index.html
+++ b/blog/silica-sand-exporter-from-india/blog/quartz-powder-supplier-for-engineered-stone/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Powder Supplier for Engineered Stone: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/");</script>

--- a/blog/silica-sand-exporter-from-india/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
+++ b/blog/silica-sand-exporter-from-india/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand Supplier from India: Buyer Checklist for Vietnam Ceramics and Glass Teams moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/");</script>

--- a/blog/silica-sand-exporter-from-india/blog/silica-sand-exporter-from-india/index.html
+++ b/blog/silica-sand-exporter-from-india/blog/silica-sand-exporter-from-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Exporter from India: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/");</script>

--- a/blog/silica-sand-exporter-from-india/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
+++ b/blog/silica-sand-exporter-from-india/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Import Checklist for Glass, Foundry, and Filtration Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/");</script>

--- a/blog/silica-sand-exporter-from-india/export-markets/index.html
+++ b/blog/silica-sand-exporter-from-india/export-markets/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export Markets moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/blog/silica-sand-exporter-from-india/hear-from-ceo/index.html
+++ b/blog/silica-sand-exporter-from-india/hear-from-ceo/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hear From Ceo moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/hear-from-ceo/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/hear-from-ceo/" />
     <script>window.location.replace("https://jadewavesenterprise.com/hear-from-ceo/");</script>

--- a/blog/silica-sand-exporter-from-india/operations/index.html
+++ b/blog/silica-sand-exporter-from-india/operations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Operations moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/blog/silica-sand-exporter-from-india/privacy-policy/index.html
+++ b/blog/silica-sand-exporter-from-india/privacy-policy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/privacy-policy/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/privacy-policy/" />
     <script>window.location.replace("https://jadewavesenterprise.com/privacy-policy/");</script>

--- a/blog/silica-sand-exporter-from-india/products/bentonite/index.html
+++ b/blog/silica-sand-exporter-from-india/products/bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/blog/silica-sand-exporter-from-india/products/copper-slag/index.html
+++ b/blog/silica-sand-exporter-from-india/products/copper-slag/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/blog/silica-sand-exporter-from-india/products/feldspar/index.html
+++ b/blog/silica-sand-exporter-from-india/products/feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/blog/silica-sand-exporter-from-india/products/fly-ash/index.html
+++ b/blog/silica-sand-exporter-from-india/products/fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>

--- a/blog/silica-sand-exporter-from-india/products/index.html
+++ b/blog/silica-sand-exporter-from-india/products/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Products moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/blog/silica-sand-exporter-from-india/products/kaolin--china-clay/index.html
+++ b/blog/silica-sand-exporter-from-india/products/kaolin--china-clay/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin (China Clay) moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/blog/silica-sand-exporter-from-india/products/quartz-sand-for-ceramics/index.html
+++ b/blog/silica-sand-exporter-from-india/products/quartz-sand-for-ceramics/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/blog/silica-sand-exporter-from-india/products/salt/index.html
+++ b/blog/silica-sand-exporter-from-india/products/salt/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/blog/silica-sand-exporter-from-india/products/silica-flour/index.html
+++ b/blog/silica-sand-exporter-from-india/products/silica-flour/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Flour moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>

--- a/blog/silica-sand-exporter-from-india/products/silica-sand/index.html
+++ b/blog/silica-sand-exporter-from-india/products/silica-sand/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/blog/silica-sand-exporter-from-india/products/talc/index.html
+++ b/blog/silica-sand-exporter-from-india/products/talc/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/blog/silica-sand-exporter-from-india/terms-disclaimer/index.html
+++ b/blog/silica-sand-exporter-from-india/terms-disclaimer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms Disclaimer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/bentonite-grade-selection-guide-for-importers/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/bentonite-grade-selection-guide-for-importers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Grade Selection Guide for Drilling, Foundry, and Civil Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-grade-selection-guide-for-importers/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/bentonite-supplier-india/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/bentonite-supplier-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Supplier India: What We Offer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/bentonite-supplier-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/bentonite-supplier-india/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/copper-slag-supplier-for-shipyard-blasting/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/copper-slag-supplier-for-shipyard-blasting/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag Supplier for Shipyard Blasting: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/fly-ash-exporter-from-india-bulk-shipment/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash Exporter from India Bulk Shipment: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/how-to-check-tds-and-sample-coa-before-mineral-import/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>How to Check TDS and Sample COA Before You Place a Mineral Import Order moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/how-to-check-tds-and-sample-coa-before-mineral-import/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/industrial-salt-exporter/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/industrial-salt-exporter/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Exporter: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-exporter/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/industrial-salt-import-guide-gulf-buyers/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/industrial-salt-import-guide-gulf-buyers/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Industrial Salt Import Guide for UAE, Oman, Qatar, and Kuwait Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-import-guide-gulf-buyers/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/kaolin-supplier-for-paint-industry/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/kaolin-supplier-for-paint-industry/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin Supplier for Paint Industry: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/kaolin-supplier-for-paint-industry/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/potassium-feldspar-supplier-for-ceramic-tiles/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium Feldspar Supplier for Ceramic Tiles: Export-Ready Supply for Manufacturers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/potassium-vs-sodium-feldspar-import-buyer-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potassium vs Sodium Feldspar: What Import Buyers Should Confirm Before Buying moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-vs-sodium-feldspar-import-buyer-guide/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/quartz-powder-supplier-for-engineered-stone/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/quartz-powder-supplier-for-engineered-stone/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Powder Supplier for Engineered Stone: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-powder-supplier-for-engineered-stone/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/quartz-sand-supplier-india-vietnam-buyers-guide/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand Supplier from India: Buyer Checklist for Vietnam Ceramics and Glass Teams moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/silica-sand-exporter-from-india/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/silica-sand-exporter-from-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Exporter from India: What We Supply moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/blog/silica-sand-import-checklist-glass-foundry-filtration/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand Import Checklist for Glass, Foundry, and Filtration Buyers moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-import-checklist-glass-foundry-filtration/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/export-markets/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/export-markets/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export Markets moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/hear-from-ceo/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/hear-from-ceo/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hear From Ceo moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/hear-from-ceo/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/hear-from-ceo/" />
     <script>window.location.replace("https://jadewavesenterprise.com/hear-from-ceo/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/operations/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/operations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Operations moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/privacy-policy/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/privacy-policy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/privacy-policy/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/privacy-policy/" />
     <script>window.location.replace("https://jadewavesenterprise.com/privacy-policy/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/products/bentonite/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/products/bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/products/copper-slag/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/products/copper-slag/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/products/feldspar/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/products/feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/products/fly-ash/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/products/fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/products/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/products/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Products moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/products/kaolin--china-clay/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/products/kaolin--china-clay/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin (China Clay) moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/products/quartz-sand-for-ceramics/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/products/quartz-sand-for-ceramics/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/products/salt/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/products/salt/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/products/silica-flour/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/products/silica-flour/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Flour moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/products/silica-sand/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/products/silica-sand/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/products/talc/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/products/talc/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/blog/silica-sand-import-checklist-glass-foundry-filtration/terms-disclaimer/index.html
+++ b/blog/silica-sand-import-checklist-glass-foundry-filtration/terms-disclaimer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms Disclaimer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>

--- a/blogs/f/activated-bleaching-earth/index.html
+++ b/blogs/f/activated-bleaching-earth/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Activated bleaching earth article moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/blogs/f/bentonite-clay-and-its-applications/index.html
+++ b/blogs/f/bentonite-clay-and-its-applications/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite applications article moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/blogs/f/bentonite-suppliers-in-malaysia/index.html
+++ b/blogs/f/bentonite-suppliers-in-malaysia/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Malaysia article moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/blogs/f/bentonite-suppliers-in-saudi-arabia/index.html
+++ b/blogs/f/bentonite-suppliers-in-saudi-arabia/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Saudi Arabia article moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/blogs/f/bentonite-suppliers-in-vietnam/index.html
+++ b/blogs/f/bentonite-suppliers-in-vietnam/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite Vietnam article moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/blogs/f/copper-slag-for-sandblasting/index.html
+++ b/blogs/f/copper-slag-for-sandblasting/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper slag sandblasting article moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/copper-slag-supplier-for-shipyard-blasting/");</script>

--- a/blogs/f/copper-slag-suppliers-in-india/index.html
+++ b/blogs/f/copper-slag-suppliers-in-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper slag supplier article moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/blogs/f/drilling-bentonite/index.html
+++ b/blogs/f/drilling-bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Drilling bentonite article moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/blogs/f/fly-ash-suppliers-in-india/index.html
+++ b/blogs/f/fly-ash-suppliers-in-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly ash supplier article moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/");</script>

--- a/blogs/f/innovations-in-recycling-fly-ash/index.html
+++ b/blogs/f/innovations-in-recycling-fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly ash recycling article moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/");</script>

--- a/blogs/f/kaolin-china-clay-suppliers-in-india/index.html
+++ b/blogs/f/kaolin-china-clay-suppliers-in-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin article moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/blogs/f/paint-bentonite/index.html
+++ b/blogs/f/paint-bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Paint bentonite article moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/blogs/f/potash-feldspar-feldspar-suppliers-india/index.html
+++ b/blogs/f/potash-feldspar-feldspar-suppliers-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Potash feldspar article moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/potassium-feldspar-supplier-for-ceramic-tiles/");</script>

--- a/blogs/f/quartz-supplier-in-vietnam---quartz-india/index.html
+++ b/blogs/f/quartz-supplier-in-vietnam---quartz-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Vietnam article moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/quartz-sand-supplier-india-vietnam-buyers-guide/");</script>

--- a/blogs/f/rubber-granules-maldives-rubber-granules-supplier-in-maldives/index.html
+++ b/blogs/f/rubber-granules-maldives-rubber-granules-supplier-in-maldives/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Rubber granules article moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/blogs/f/salt-suppliers-in-mauritius-jade-waves-enterprise/index.html
+++ b/blogs/f/salt-suppliers-in-mauritius-jade-waves-enterprise/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt Mauritius article moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-exporter/");</script>

--- a/blogs/f/salt-suppliers-in-seychelles-jade-waves-enteprise/index.html
+++ b/blogs/f/salt-suppliers-in-seychelles-jade-waves-enteprise/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt Seychelles article moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-exporter/");</script>

--- a/blogs/f/salt-suppliers-in-seychelles-jade-waves-enterprise/index.html
+++ b/blogs/f/salt-suppliers-in-seychelles-jade-waves-enterprise/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt Seychelles article moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/industrial-salt-exporter/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/industrial-salt-exporter/");</script>

--- a/blogs/f/salt-the-essential-mineral/index.html
+++ b/blogs/f/salt-the-essential-mineral/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt article moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/blogs/f/silica-sand-for-artificial-football-turf/index.html
+++ b/blogs/f/silica-sand-for-artificial-football-turf/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica turf article moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/blogs/f/silica-sand-maldives/index.html
+++ b/blogs/f/silica-sand-maldives/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica sand Maldives article moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/blogs/f/silica-sand-suppliers-in-kenya/index.html
+++ b/blogs/f/silica-sand-suppliers-in-kenya/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Kenya article moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/");</script>

--- a/blogs/f/silica-sand-suppliers-in-mauritius-jade-waves-enterprise/index.html
+++ b/blogs/f/silica-sand-suppliers-in-mauritius-jade-waves-enterprise/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Mauritius article moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/blogs/f/the-future-of-fly-ash-utilization-in-green-building-practices/index.html
+++ b/blogs/f/the-future-of-fly-ash-utilization-in-green-building-practices/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly ash green building article moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/");</script>

--- a/blogs/f/the-role-of-fly-ash-in-cement-manufacturing/index.html
+++ b/blogs/f/the-role-of-fly-ash-in-cement-manufacturing/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly ash cement article moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/fly-ash-exporter-from-india-bulk-shipment/");</script>

--- a/blogs/f/top-silica-sand-suppliers-in-india-jade-waves-enterprise/index.html
+++ b/blogs/f/top-silica-sand-suppliers-in-india-jade-waves-enterprise/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica suppliers article moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/silica-sand-exporter-from-india/");</script>

--- a/blogs/index.html
+++ b/blogs/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog index moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/cat-litter-bentonite/index.html
+++ b/cat-litter-bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Cat litter bentonite moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/ceramics-bentonite/index.html
+++ b/ceramics-bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Ceramics bentonite moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/company-profile/index.html
+++ b/company-profile/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Company profile moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/industrial-minerals-exporter-india/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/industrial-minerals-exporter-india/" />
     <script>window.location.replace("https://jadewavesenterprise.com/industrial-minerals-exporter-india/");</script>

--- a/contact-1/index.html
+++ b/contact-1/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Contact moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/#contact" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/#contact" />
     <script>window.location.replace("https://jadewavesenterprise.com/#contact");</script>

--- a/contact-1/ola/services/business-collaboration/index.html
+++ b/contact-1/ola/services/business-collaboration/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Business collaboration moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/#contact" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/#contact" />
     <script>window.location.replace("https://jadewavesenterprise.com/#contact");</script>

--- a/contact-1/ola/services/product-inquiry-call/index.html
+++ b/contact-1/ola/services/product-inquiry-call/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Product inquiry moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/#contact" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/#contact" />
     <script>window.location.replace("https://jadewavesenterprise.com/#contact");</script>

--- a/contact-1/ola/services/request-a-free-sample/index.html
+++ b/contact-1/ola/services/request-a-free-sample/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Sample request moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/#contact" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/#contact" />
     <script>window.location.replace("https://jadewavesenterprise.com/#contact");</script>

--- a/copper-slag/index.html
+++ b/copper-slag/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper slag moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/dolomite/index.html
+++ b/dolomite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dolomite moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/earthing-bentonite/index.html
+++ b/earthing-bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Earthing bentonite moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/export-markets/bentonite-vietnam-gulf/index.html
+++ b/export-markets/bentonite-vietnam-gulf/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export market page moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/export-markets/feldspar-vietnam/index.html
+++ b/export-markets/feldspar-vietnam/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export market page moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/export-markets/quartz-feldspar-ceramic-glass/index.html
+++ b/export-markets/quartz-feldspar-ceramic-glass/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export market page moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/export-markets/quartz-sand-vietnam/index.html
+++ b/export-markets/quartz-sand-vietnam/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export market page moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/export-markets/silica-sand-maldives/index.html
+++ b/export-markets/silica-sand-maldives/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export market page moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/faq/index.html
+++ b/faq/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>FAQ moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/feldspar/index.html
+++ b/feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/fertilizer-bentonite/index.html
+++ b/fertilizer-bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fertilizer bentonite moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/fly-ash/index.html
+++ b/fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly ash moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>

--- a/foundry-bentonite/index.html
+++ b/foundry-bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Foundry bentonite moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/generate_site.py
+++ b/generate_site.py
@@ -1560,7 +1560,7 @@ def render_redirect_page(title: str, description: str, from_path: str, to_path: 
             <meta name="viewport" content="width=device-width, initial-scale=1.0" />
             <title>{escape(title)}</title>
             <meta name="description" content="{escape(description)}" />
-            <meta name="robots" content="index,follow" />
+            <meta name="robots" content="noindex,follow" />
             <link rel="canonical" href="{escape(target_url)}" />
             <meta http-equiv="refresh" content="0; url={escape(target_url)}" />
             <script>window.location.replace({json.dumps(target_url)});</script>
@@ -9185,6 +9185,12 @@ def render_robots() -> str:
         f"""
         User-agent: *
         Allow: /
+        Disallow: /m/
+        Disallow: /assets/coas/
+        Disallow: /*?blog=
+        Disallow: /*?blogcategory=
+        Disallow: /*?trk=
+        Disallow: /*?r=
 
         Sitemap: {BASE_URL}/sitemap.xml
         """

--- a/hdd-bentonite/index.html
+++ b/hdd-bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>HDD bentonite moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/hear-from-our-ceo/index.html
+++ b/hear-from-our-ceo/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CEO page moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/hear-from-ceo/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/hear-from-ceo/" />
     <script>window.location.replace("https://jadewavesenterprise.com/hear-from-ceo/");</script>

--- a/home/index.html
+++ b/home/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Home moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/" />
     <script>window.location.replace("https://jadewavesenterprise.com/");</script>

--- a/infrastructure/index.html
+++ b/infrastructure/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Infrastructure moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/kaolin--china-clay/index.html
+++ b/kaolin--china-clay/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/limestone-/-dolomite/index.html
+++ b/limestone-/-dolomite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dolomite moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/m/create-account/index.html
+++ b/m/create-account/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Account creation moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/#contact" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/#contact" />
     <script>window.location.replace("https://jadewavesenterprise.com/#contact");</script>

--- a/m/login/index.html
+++ b/m/login/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Login moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/#contact" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/#contact" />
     <script>window.location.replace("https://jadewavesenterprise.com/#contact");</script>

--- a/m/reset/index.html
+++ b/m/reset/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Reset moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/#contact" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/#contact" />
     <script>window.location.replace("https://jadewavesenterprise.com/#contact");</script>

--- a/oil-drilling-bentonite/index.html
+++ b/oil-drilling-bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Oil drilling bentonite moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/operations/blog/index.html
+++ b/operations/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/operations/export-markets/index.html
+++ b/operations/export-markets/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Markets moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/operations/operations/index.html
+++ b/operations/operations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Operations moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/operations/privacy-policy/index.html
+++ b/operations/privacy-policy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/privacy-policy/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/privacy-policy/" />
     <script>window.location.replace("https://jadewavesenterprise.com/privacy-policy/");</script>

--- a/operations/products/bentonite/index.html
+++ b/operations/products/bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/operations/products/copper-slag/index.html
+++ b/operations/products/copper-slag/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/operations/products/feldspar/index.html
+++ b/operations/products/feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/operations/products/fly-ash/index.html
+++ b/operations/products/fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>

--- a/operations/products/kaolin--china-clay/index.html
+++ b/operations/products/kaolin--china-clay/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin (China Clay) moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/operations/products/quartz-sand-for-ceramics/index.html
+++ b/operations/products/quartz-sand-for-ceramics/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/operations/products/salt/index.html
+++ b/operations/products/salt/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/operations/products/silica-flour/index.html
+++ b/operations/products/silica-flour/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Flour moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>

--- a/operations/products/silica-sand/index.html
+++ b/operations/products/silica-sand/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/operations/products/talc/index.html
+++ b/operations/products/talc/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/operations/terms-disclaimer/index.html
+++ b/operations/terms-disclaimer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>

--- a/piling-bentonite/index.html
+++ b/piling-bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Piling bentonite moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/pond-sealing-bentonite/index.html
+++ b/pond-sealing-bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Pond sealing bentonite moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/potash-&-soda-feldspar/index.html
+++ b/potash-&-soda-feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/privacy-policy/privacy-policy/index.html
+++ b/privacy-policy/privacy-policy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/privacy-policy/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/privacy-policy/" />
     <script>window.location.replace("https://jadewavesenterprise.com/privacy-policy/");</script>

--- a/privacy-policy/terms-disclaimer/index.html
+++ b/privacy-policy/terms-disclaimer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>

--- a/products/bentonite/blog/index.html
+++ b/products/bentonite/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/products/bentonite/export-markets/index.html
+++ b/products/bentonite/export-markets/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export Markets moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/products/bentonite/hear-from-ceo/index.html
+++ b/products/bentonite/hear-from-ceo/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hear From Ceo moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/hear-from-ceo/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/hear-from-ceo/" />
     <script>window.location.replace("https://jadewavesenterprise.com/hear-from-ceo/");</script>

--- a/products/bentonite/operations/index.html
+++ b/products/bentonite/operations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Operations moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/products/bentonite/privacy-policy/index.html
+++ b/products/bentonite/privacy-policy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/privacy-policy/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/privacy-policy/" />
     <script>window.location.replace("https://jadewavesenterprise.com/privacy-policy/");</script>

--- a/products/bentonite/products/bentonite/index.html
+++ b/products/bentonite/products/bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/products/bentonite/products/copper-slag/index.html
+++ b/products/bentonite/products/copper-slag/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/products/bentonite/products/feldspar/index.html
+++ b/products/bentonite/products/feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/products/bentonite/products/fly-ash/index.html
+++ b/products/bentonite/products/fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>

--- a/products/bentonite/products/index.html
+++ b/products/bentonite/products/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Products moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/products/bentonite/products/kaolin--china-clay/index.html
+++ b/products/bentonite/products/kaolin--china-clay/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin (China Clay) moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/products/bentonite/products/quartz-sand-for-ceramics/index.html
+++ b/products/bentonite/products/quartz-sand-for-ceramics/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/products/bentonite/products/salt/index.html
+++ b/products/bentonite/products/salt/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/products/bentonite/products/silica-flour/index.html
+++ b/products/bentonite/products/silica-flour/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Flour moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>

--- a/products/bentonite/products/silica-sand/index.html
+++ b/products/bentonite/products/silica-sand/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/products/bentonite/products/talc/index.html
+++ b/products/bentonite/products/talc/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/products/bentonite/terms-disclaimer/index.html
+++ b/products/bentonite/terms-disclaimer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms Disclaimer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>

--- a/products/blog/index.html
+++ b/products/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/products/copper-slag/blog/index.html
+++ b/products/copper-slag/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/products/copper-slag/export-markets/index.html
+++ b/products/copper-slag/export-markets/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export Markets moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/products/copper-slag/hear-from-ceo/index.html
+++ b/products/copper-slag/hear-from-ceo/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hear From Ceo moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/hear-from-ceo/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/hear-from-ceo/" />
     <script>window.location.replace("https://jadewavesenterprise.com/hear-from-ceo/");</script>

--- a/products/copper-slag/operations/index.html
+++ b/products/copper-slag/operations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Operations moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/products/copper-slag/privacy-policy/index.html
+++ b/products/copper-slag/privacy-policy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/privacy-policy/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/privacy-policy/" />
     <script>window.location.replace("https://jadewavesenterprise.com/privacy-policy/");</script>

--- a/products/copper-slag/products/bentonite/index.html
+++ b/products/copper-slag/products/bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/products/copper-slag/products/copper-slag/index.html
+++ b/products/copper-slag/products/copper-slag/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/products/copper-slag/products/feldspar/index.html
+++ b/products/copper-slag/products/feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/products/copper-slag/products/fly-ash/index.html
+++ b/products/copper-slag/products/fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>

--- a/products/copper-slag/products/index.html
+++ b/products/copper-slag/products/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Products moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/products/copper-slag/products/kaolin--china-clay/index.html
+++ b/products/copper-slag/products/kaolin--china-clay/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin (China Clay) moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/products/copper-slag/products/quartz-sand-for-ceramics/index.html
+++ b/products/copper-slag/products/quartz-sand-for-ceramics/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/products/copper-slag/products/salt/index.html
+++ b/products/copper-slag/products/salt/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/products/copper-slag/products/silica-flour/index.html
+++ b/products/copper-slag/products/silica-flour/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Flour moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>

--- a/products/copper-slag/products/silica-sand/index.html
+++ b/products/copper-slag/products/silica-sand/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/products/copper-slag/products/talc/index.html
+++ b/products/copper-slag/products/talc/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/products/copper-slag/terms-disclaimer/index.html
+++ b/products/copper-slag/terms-disclaimer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms Disclaimer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>

--- a/products/export-markets/index.html
+++ b/products/export-markets/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Markets moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/products/feldspar/blog/index.html
+++ b/products/feldspar/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/products/feldspar/export-markets/index.html
+++ b/products/feldspar/export-markets/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export Markets moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/products/feldspar/hear-from-ceo/index.html
+++ b/products/feldspar/hear-from-ceo/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hear From Ceo moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/hear-from-ceo/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/hear-from-ceo/" />
     <script>window.location.replace("https://jadewavesenterprise.com/hear-from-ceo/");</script>

--- a/products/feldspar/operations/index.html
+++ b/products/feldspar/operations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Operations moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/products/feldspar/privacy-policy/index.html
+++ b/products/feldspar/privacy-policy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/privacy-policy/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/privacy-policy/" />
     <script>window.location.replace("https://jadewavesenterprise.com/privacy-policy/");</script>

--- a/products/feldspar/products/bentonite/index.html
+++ b/products/feldspar/products/bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/products/feldspar/products/copper-slag/index.html
+++ b/products/feldspar/products/copper-slag/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/products/feldspar/products/feldspar/index.html
+++ b/products/feldspar/products/feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/products/feldspar/products/fly-ash/index.html
+++ b/products/feldspar/products/fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>

--- a/products/feldspar/products/index.html
+++ b/products/feldspar/products/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Products moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/products/feldspar/products/kaolin--china-clay/index.html
+++ b/products/feldspar/products/kaolin--china-clay/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin (China Clay) moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/products/feldspar/products/quartz-sand-for-ceramics/index.html
+++ b/products/feldspar/products/quartz-sand-for-ceramics/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/products/feldspar/products/salt/index.html
+++ b/products/feldspar/products/salt/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/products/feldspar/products/silica-flour/index.html
+++ b/products/feldspar/products/silica-flour/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Flour moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>

--- a/products/feldspar/products/silica-sand/index.html
+++ b/products/feldspar/products/silica-sand/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/products/feldspar/products/talc/index.html
+++ b/products/feldspar/products/talc/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/products/feldspar/terms-disclaimer/index.html
+++ b/products/feldspar/terms-disclaimer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms Disclaimer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>

--- a/products/fly-ash/blog/index.html
+++ b/products/fly-ash/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/products/fly-ash/export-markets/index.html
+++ b/products/fly-ash/export-markets/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export Markets moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/products/fly-ash/hear-from-ceo/index.html
+++ b/products/fly-ash/hear-from-ceo/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hear From Ceo moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/hear-from-ceo/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/hear-from-ceo/" />
     <script>window.location.replace("https://jadewavesenterprise.com/hear-from-ceo/");</script>

--- a/products/fly-ash/operations/index.html
+++ b/products/fly-ash/operations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Operations moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/products/fly-ash/privacy-policy/index.html
+++ b/products/fly-ash/privacy-policy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/privacy-policy/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/privacy-policy/" />
     <script>window.location.replace("https://jadewavesenterprise.com/privacy-policy/");</script>

--- a/products/fly-ash/products/bentonite/index.html
+++ b/products/fly-ash/products/bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/products/fly-ash/products/copper-slag/index.html
+++ b/products/fly-ash/products/copper-slag/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/products/fly-ash/products/feldspar/index.html
+++ b/products/fly-ash/products/feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/products/fly-ash/products/fly-ash/index.html
+++ b/products/fly-ash/products/fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>

--- a/products/fly-ash/products/index.html
+++ b/products/fly-ash/products/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Products moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/products/fly-ash/products/kaolin--china-clay/index.html
+++ b/products/fly-ash/products/kaolin--china-clay/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin (China Clay) moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/products/fly-ash/products/quartz-sand-for-ceramics/index.html
+++ b/products/fly-ash/products/quartz-sand-for-ceramics/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/products/fly-ash/products/salt/index.html
+++ b/products/fly-ash/products/salt/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/products/fly-ash/products/silica-flour/index.html
+++ b/products/fly-ash/products/silica-flour/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Flour moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>

--- a/products/fly-ash/products/silica-sand/index.html
+++ b/products/fly-ash/products/silica-sand/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/products/fly-ash/products/talc/index.html
+++ b/products/fly-ash/products/talc/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/products/fly-ash/terms-disclaimer/index.html
+++ b/products/fly-ash/terms-disclaimer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms Disclaimer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>

--- a/products/kaolin--china-clay/blog/index.html
+++ b/products/kaolin--china-clay/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/products/kaolin--china-clay/export-markets/index.html
+++ b/products/kaolin--china-clay/export-markets/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export Markets moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/products/kaolin--china-clay/hear-from-ceo/index.html
+++ b/products/kaolin--china-clay/hear-from-ceo/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hear From Ceo moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/hear-from-ceo/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/hear-from-ceo/" />
     <script>window.location.replace("https://jadewavesenterprise.com/hear-from-ceo/");</script>

--- a/products/kaolin--china-clay/operations/index.html
+++ b/products/kaolin--china-clay/operations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Operations moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/products/kaolin--china-clay/privacy-policy/index.html
+++ b/products/kaolin--china-clay/privacy-policy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/privacy-policy/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/privacy-policy/" />
     <script>window.location.replace("https://jadewavesenterprise.com/privacy-policy/");</script>

--- a/products/kaolin--china-clay/products/bentonite/index.html
+++ b/products/kaolin--china-clay/products/bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/products/kaolin--china-clay/products/copper-slag/index.html
+++ b/products/kaolin--china-clay/products/copper-slag/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/products/kaolin--china-clay/products/feldspar/index.html
+++ b/products/kaolin--china-clay/products/feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/products/kaolin--china-clay/products/fly-ash/index.html
+++ b/products/kaolin--china-clay/products/fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>

--- a/products/kaolin--china-clay/products/index.html
+++ b/products/kaolin--china-clay/products/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Products moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/products/kaolin--china-clay/products/kaolin--china-clay/index.html
+++ b/products/kaolin--china-clay/products/kaolin--china-clay/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin (China Clay) moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/products/kaolin--china-clay/products/quartz-sand-for-ceramics/index.html
+++ b/products/kaolin--china-clay/products/quartz-sand-for-ceramics/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/products/kaolin--china-clay/products/salt/index.html
+++ b/products/kaolin--china-clay/products/salt/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/products/kaolin--china-clay/products/silica-flour/index.html
+++ b/products/kaolin--china-clay/products/silica-flour/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Flour moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>

--- a/products/kaolin--china-clay/products/silica-sand/index.html
+++ b/products/kaolin--china-clay/products/silica-sand/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/products/kaolin--china-clay/products/talc/index.html
+++ b/products/kaolin--china-clay/products/talc/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/products/kaolin--china-clay/terms-disclaimer/index.html
+++ b/products/kaolin--china-clay/terms-disclaimer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms Disclaimer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>

--- a/products/operations/index.html
+++ b/products/operations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Operations moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/products/products/bentonite/index.html
+++ b/products/products/bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/products/products/copper-slag/index.html
+++ b/products/products/copper-slag/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/products/products/feldspar/index.html
+++ b/products/products/feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/products/products/fly-ash/index.html
+++ b/products/products/fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>

--- a/products/products/index.html
+++ b/products/products/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Products moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/products/products/kaolin--china-clay/index.html
+++ b/products/products/kaolin--china-clay/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin (China Clay) moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/products/products/quartz-sand-for-ceramics/index.html
+++ b/products/products/quartz-sand-for-ceramics/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/products/products/salt/index.html
+++ b/products/products/salt/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/products/products/silica-flour/index.html
+++ b/products/products/silica-flour/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Flour moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>

--- a/products/products/silica-sand/index.html
+++ b/products/products/silica-sand/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/products/products/talc/index.html
+++ b/products/products/talc/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/products/quartz-sand-for-ceramics/blog/index.html
+++ b/products/quartz-sand-for-ceramics/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/products/quartz-sand-for-ceramics/export-markets/index.html
+++ b/products/quartz-sand-for-ceramics/export-markets/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export Markets moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/products/quartz-sand-for-ceramics/hear-from-ceo/index.html
+++ b/products/quartz-sand-for-ceramics/hear-from-ceo/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hear From Ceo moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/hear-from-ceo/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/hear-from-ceo/" />
     <script>window.location.replace("https://jadewavesenterprise.com/hear-from-ceo/");</script>

--- a/products/quartz-sand-for-ceramics/operations/index.html
+++ b/products/quartz-sand-for-ceramics/operations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Operations moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/products/quartz-sand-for-ceramics/privacy-policy/index.html
+++ b/products/quartz-sand-for-ceramics/privacy-policy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/privacy-policy/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/privacy-policy/" />
     <script>window.location.replace("https://jadewavesenterprise.com/privacy-policy/");</script>

--- a/products/quartz-sand-for-ceramics/products/bentonite/index.html
+++ b/products/quartz-sand-for-ceramics/products/bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/products/quartz-sand-for-ceramics/products/copper-slag/index.html
+++ b/products/quartz-sand-for-ceramics/products/copper-slag/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/products/quartz-sand-for-ceramics/products/feldspar/index.html
+++ b/products/quartz-sand-for-ceramics/products/feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/products/quartz-sand-for-ceramics/products/fly-ash/index.html
+++ b/products/quartz-sand-for-ceramics/products/fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>

--- a/products/quartz-sand-for-ceramics/products/index.html
+++ b/products/quartz-sand-for-ceramics/products/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Products moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/products/quartz-sand-for-ceramics/products/kaolin--china-clay/index.html
+++ b/products/quartz-sand-for-ceramics/products/kaolin--china-clay/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin (China Clay) moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/products/quartz-sand-for-ceramics/products/quartz-sand-for-ceramics/index.html
+++ b/products/quartz-sand-for-ceramics/products/quartz-sand-for-ceramics/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/products/quartz-sand-for-ceramics/products/salt/index.html
+++ b/products/quartz-sand-for-ceramics/products/salt/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/products/quartz-sand-for-ceramics/products/silica-flour/index.html
+++ b/products/quartz-sand-for-ceramics/products/silica-flour/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Flour moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>

--- a/products/quartz-sand-for-ceramics/products/silica-sand/index.html
+++ b/products/quartz-sand-for-ceramics/products/silica-sand/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/products/quartz-sand-for-ceramics/products/talc/index.html
+++ b/products/quartz-sand-for-ceramics/products/talc/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/products/quartz-sand-for-ceramics/terms-disclaimer/index.html
+++ b/products/quartz-sand-for-ceramics/terms-disclaimer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms Disclaimer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>

--- a/products/salt/blog/index.html
+++ b/products/salt/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/products/salt/export-markets/index.html
+++ b/products/salt/export-markets/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export Markets moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/products/salt/hear-from-ceo/index.html
+++ b/products/salt/hear-from-ceo/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hear From Ceo moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/hear-from-ceo/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/hear-from-ceo/" />
     <script>window.location.replace("https://jadewavesenterprise.com/hear-from-ceo/");</script>

--- a/products/salt/operations/index.html
+++ b/products/salt/operations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Operations moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/products/salt/privacy-policy/index.html
+++ b/products/salt/privacy-policy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/privacy-policy/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/privacy-policy/" />
     <script>window.location.replace("https://jadewavesenterprise.com/privacy-policy/");</script>

--- a/products/salt/products/bentonite/index.html
+++ b/products/salt/products/bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/products/salt/products/copper-slag/index.html
+++ b/products/salt/products/copper-slag/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/products/salt/products/feldspar/index.html
+++ b/products/salt/products/feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/products/salt/products/fly-ash/index.html
+++ b/products/salt/products/fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>

--- a/products/salt/products/index.html
+++ b/products/salt/products/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Products moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/products/salt/products/kaolin--china-clay/index.html
+++ b/products/salt/products/kaolin--china-clay/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin (China Clay) moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/products/salt/products/quartz-sand-for-ceramics/index.html
+++ b/products/salt/products/quartz-sand-for-ceramics/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/products/salt/products/salt/index.html
+++ b/products/salt/products/salt/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/products/salt/products/silica-flour/index.html
+++ b/products/salt/products/silica-flour/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Flour moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>

--- a/products/salt/products/silica-sand/index.html
+++ b/products/salt/products/silica-sand/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/products/salt/products/talc/index.html
+++ b/products/salt/products/talc/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/products/salt/terms-disclaimer/index.html
+++ b/products/salt/terms-disclaimer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms Disclaimer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>

--- a/products/silica-flour/blog/index.html
+++ b/products/silica-flour/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/products/silica-flour/export-markets/index.html
+++ b/products/silica-flour/export-markets/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export Markets moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/products/silica-flour/hear-from-ceo/index.html
+++ b/products/silica-flour/hear-from-ceo/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hear From Ceo moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/hear-from-ceo/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/hear-from-ceo/" />
     <script>window.location.replace("https://jadewavesenterprise.com/hear-from-ceo/");</script>

--- a/products/silica-flour/operations/index.html
+++ b/products/silica-flour/operations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Operations moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/products/silica-flour/privacy-policy/index.html
+++ b/products/silica-flour/privacy-policy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/privacy-policy/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/privacy-policy/" />
     <script>window.location.replace("https://jadewavesenterprise.com/privacy-policy/");</script>

--- a/products/silica-flour/products/bentonite/index.html
+++ b/products/silica-flour/products/bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/products/silica-flour/products/copper-slag/index.html
+++ b/products/silica-flour/products/copper-slag/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/products/silica-flour/products/feldspar/index.html
+++ b/products/silica-flour/products/feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/products/silica-flour/products/fly-ash/index.html
+++ b/products/silica-flour/products/fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>

--- a/products/silica-flour/products/index.html
+++ b/products/silica-flour/products/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Products moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/products/silica-flour/products/kaolin--china-clay/index.html
+++ b/products/silica-flour/products/kaolin--china-clay/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin (China Clay) moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/products/silica-flour/products/quartz-sand-for-ceramics/index.html
+++ b/products/silica-flour/products/quartz-sand-for-ceramics/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/products/silica-flour/products/salt/index.html
+++ b/products/silica-flour/products/salt/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/products/silica-flour/products/silica-flour/index.html
+++ b/products/silica-flour/products/silica-flour/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Flour moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>

--- a/products/silica-flour/products/silica-sand/index.html
+++ b/products/silica-flour/products/silica-sand/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/products/silica-flour/products/talc/index.html
+++ b/products/silica-flour/products/talc/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/products/silica-flour/terms-disclaimer/index.html
+++ b/products/silica-flour/terms-disclaimer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms Disclaimer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>

--- a/products/silica-sand/blog/index.html
+++ b/products/silica-sand/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/products/silica-sand/export-markets/index.html
+++ b/products/silica-sand/export-markets/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export Markets moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/products/silica-sand/hear-from-ceo/index.html
+++ b/products/silica-sand/hear-from-ceo/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hear From Ceo moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/hear-from-ceo/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/hear-from-ceo/" />
     <script>window.location.replace("https://jadewavesenterprise.com/hear-from-ceo/");</script>

--- a/products/silica-sand/operations/index.html
+++ b/products/silica-sand/operations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Operations moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/products/silica-sand/privacy-policy/index.html
+++ b/products/silica-sand/privacy-policy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/privacy-policy/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/privacy-policy/" />
     <script>window.location.replace("https://jadewavesenterprise.com/privacy-policy/");</script>

--- a/products/silica-sand/products/bentonite/index.html
+++ b/products/silica-sand/products/bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/products/silica-sand/products/copper-slag/index.html
+++ b/products/silica-sand/products/copper-slag/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/products/silica-sand/products/feldspar/index.html
+++ b/products/silica-sand/products/feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/products/silica-sand/products/fly-ash/index.html
+++ b/products/silica-sand/products/fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>

--- a/products/silica-sand/products/index.html
+++ b/products/silica-sand/products/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Products moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/products/silica-sand/products/kaolin--china-clay/index.html
+++ b/products/silica-sand/products/kaolin--china-clay/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin (China Clay) moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/products/silica-sand/products/quartz-sand-for-ceramics/index.html
+++ b/products/silica-sand/products/quartz-sand-for-ceramics/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/products/silica-sand/products/salt/index.html
+++ b/products/silica-sand/products/salt/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/products/silica-sand/products/silica-flour/index.html
+++ b/products/silica-sand/products/silica-flour/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Flour moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>

--- a/products/silica-sand/products/silica-sand/index.html
+++ b/products/silica-sand/products/silica-sand/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/products/silica-sand/products/talc/index.html
+++ b/products/silica-sand/products/talc/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/products/silica-sand/terms-disclaimer/index.html
+++ b/products/silica-sand/terms-disclaimer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms Disclaimer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>

--- a/products/talc/blog/index.html
+++ b/products/talc/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/blog/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/blog/" />
     <script>window.location.replace("https://jadewavesenterprise.com/blog/");</script>

--- a/products/talc/export-markets/index.html
+++ b/products/talc/export-markets/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Export Markets moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/export-markets/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/export-markets/" />
     <script>window.location.replace("https://jadewavesenterprise.com/export-markets/");</script>

--- a/products/talc/hear-from-ceo/index.html
+++ b/products/talc/hear-from-ceo/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hear From Ceo moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/hear-from-ceo/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/hear-from-ceo/" />
     <script>window.location.replace("https://jadewavesenterprise.com/hear-from-ceo/");</script>

--- a/products/talc/operations/index.html
+++ b/products/talc/operations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Operations moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/operations/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/operations/" />
     <script>window.location.replace("https://jadewavesenterprise.com/operations/");</script>

--- a/products/talc/privacy-policy/index.html
+++ b/products/talc/privacy-policy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/privacy-policy/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/privacy-policy/" />
     <script>window.location.replace("https://jadewavesenterprise.com/privacy-policy/");</script>

--- a/products/talc/products/bentonite/index.html
+++ b/products/talc/products/bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bentonite moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/products/talc/products/copper-slag/index.html
+++ b/products/talc/products/copper-slag/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Copper Slag moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/copper-slag/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/copper-slag/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/copper-slag/");</script>

--- a/products/talc/products/feldspar/index.html
+++ b/products/talc/products/feldspar/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Feldspar moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/feldspar/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/feldspar/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/feldspar/");</script>

--- a/products/talc/products/fly-ash/index.html
+++ b/products/talc/products/fly-ash/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fly Ash moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/fly-ash/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/fly-ash/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/fly-ash/");</script>

--- a/products/talc/products/index.html
+++ b/products/talc/products/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Products moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/products/talc/products/kaolin--china-clay/index.html
+++ b/products/talc/products/kaolin--china-clay/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kaolin (China Clay) moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/kaolin--china-clay/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/kaolin--china-clay/");</script>

--- a/products/talc/products/quartz-sand-for-ceramics/index.html
+++ b/products/talc/products/quartz-sand-for-ceramics/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/products/talc/products/salt/index.html
+++ b/products/talc/products/salt/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/products/talc/products/silica-flour/index.html
+++ b/products/talc/products/silica-flour/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Flour moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>

--- a/products/talc/products/silica-sand/index.html
+++ b/products/talc/products/silica-sand/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica Sand moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/products/talc/products/talc/index.html
+++ b/products/talc/products/talc/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/products/talc/terms-disclaimer/index.html
+++ b/products/talc/terms-disclaimer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms Disclaimer moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>

--- a/quartz-sand-for-ceramics/index.html
+++ b/quartz-sand-for-ceramics/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz sand moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/quartz/index.html
+++ b/quartz/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/quartz-sand-for-ceramics/");</script>

--- a/refractory-bentonite/index.html
+++ b/refractory-bentonite/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Refractory bentonite moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/bentonite/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/bentonite/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/bentonite/");</script>

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,10 @@
 User-agent: *
 Allow: /
+Disallow: /m/
+Disallow: /assets/coas/
+Disallow: /*?blog=
+Disallow: /*?blogcategory=
+Disallow: /*?trk=
+Disallow: /*?r=
 
 Sitemap: https://jadewavesenterprise.com/sitemap.xml

--- a/rubber-granules/index.html
+++ b/rubber-granules/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Rubber granules moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/");</script>

--- a/salt/index.html
+++ b/salt/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Salt moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/salt/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/salt/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/salt/");</script>

--- a/silica-flour/index.html
+++ b/silica-flour/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica flour moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-flour/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-flour/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-flour/");</script>

--- a/silica-sand-india/index.html
+++ b/silica-sand-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica sand moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/silica-sand/index.html
+++ b/silica-sand/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica sand moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/silicasand-supplier-india/index.html
+++ b/silicasand-supplier-india/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Silica sand moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/silica-sand/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/silica-sand/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/silica-sand/");</script>

--- a/talc-/-soapstone/index.html
+++ b/talc-/-soapstone/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/talc/index.html
+++ b/talc/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Talc moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/products/talc/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/products/talc/" />
     <script>window.location.replace("https://jadewavesenterprise.com/products/talc/");</script>

--- a/terms-and-conditions/index.html
+++ b/terms-and-conditions/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms moved</title>
     <meta name="description" content="This legacy URL now points to the current Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>

--- a/terms-disclaimer/privacy-policy/index.html
+++ b/terms-disclaimer/privacy-policy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/privacy-policy/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/privacy-policy/" />
     <script>window.location.replace("https://jadewavesenterprise.com/privacy-policy/");</script>

--- a/terms-disclaimer/terms-disclaimer/index.html
+++ b/terms-disclaimer/terms-disclaimer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms moved</title>
     <meta name="description" content="This malformed legacy URL now points to the canonical Jade Waves page." />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <link rel="canonical" href="https://jadewavesenterprise.com/terms-disclaimer/" />
     <meta http-equiv="refresh" content="0; url=https://jadewavesenterprise.com/terms-disclaimer/" />
     <script>window.location.replace("https://jadewavesenterprise.com/terms-disclaimer/");</script>


### PR DESCRIPTION
## Summary\n- mark generated legacy redirect pages as noindex so Google stops reconsidering them for indexing\n- disallow login/account, sample COA asset, and junk query-parameter crawl patterns in robots.txt\n- keep canonical targets and legacy coverage in place so old URLs still resolve without reintroducing 404s\n\n## Validation\n- python3 generate_site.py\n- python3 scripts/build_site.py\n- verified generated legacy aliases now emit noindex,follow\n- verified robots.txt contains the new disallow rules